### PR TITLE
Add support for building a custom YBDB Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,24 @@
 
 - Refer to the [template directory](./template) for how to start adding scripts for your tool.
 
-- Add your top-level script in [start.sh](./start.sh) so that it gets run in the Jenkins pipeline.
+- Invoke your top-level script in [start.sh](./start.sh) so that it gets run in the Jenkins pipeline.
+
+- The [init script](./init/init.sh) runs before the tool-specific scripts and it builds a
+  Docker image off the latest master of yugabyte-db repository.
+  Alternatively, one can also make it 1) use an already created Docker image of the last updated master or
+  2) build and use the Docker image of a specific commit in the repository or
+  3) use an existing Docker image publicly available on hub.docker.com.
+  This could be specified using the environment variable `YBDB_IMAGE` either in the script itself
+  via a commit or on the Jenkins Dashaboard -> Manage Jenkins -> Configure System ->
+  Global properties.
+
+  Value of this environment variable for above cases could be:
+  ```
+  YBDB_IMAGE=latest  # Default - Clone latest master and build a new Docker image off it
+  YBDB_IMAGE=last_latest  # 1) Use the existing Docker image created off the most recent master
+  YBDB_IMAGE=sha_<commit-id>  # 2) Checkout the <commit-id> of the repository and build a new Docker image 
+  YBDB_IMAGE=dht_<image-tag>  # 3) Use existing public Docker image "yugabytedb/yugabyte:<image-tag>"
+  ```
 
 - Currently, a single pipeline runs all the scripts. A failed pipeline build means failure in at
   least one of the tool's scripts. A separate pipeline for each of the tools may be added in future.

--- a/gorm/start-ybdb.sh
+++ b/gorm/start-ybdb.sh
@@ -1,14 +1,9 @@
 #!/bin/bash
 set -e
 
-# Check if YBDB_IMAGE is defined. If not set it to a value of your choice.
-if [[ -z $YBDB_IMAGE ]]; then
-  YBDB_IMAGE=latest
-fi
-
 # Start YugabyteDB
 docker run -d --name yugabyte  -p7000:7000 -p9000:9000 -p5433:5433 -p9042:9042 \
- yugabytedb/yugabyte:$YBDB_IMAGE bin/yugabyted start \
+ $YBDB_IMAGE_PATH bin/yugabyted start \
  --daemon=false
 
 # Allow some time for cluster init

--- a/gorm/start.sh
+++ b/gorm/start.sh
@@ -9,7 +9,7 @@ CURRENT_DIR_PATH=`realpath $CURRENT_DIR`
 cd $CURRENT_DIR_PATH
 
 # Start the run
-YBDB_IMAGE=$YBDB_IMAGE bash ./do-start.sh
+YBDB_IMAGE_PATH=$YBDB_IMAGE_PATH bash ./do-start.sh
 SUCCESS="$?"
 
 # Tear down the setup

--- a/gorm/start.sh
+++ b/gorm/start.sh
@@ -16,7 +16,12 @@ SUCCESS="$?"
 printf "Executing tear-down.sh ...\n"
 . ./tear-down.sh
 
+echo "Returning $SUCCESS"
+summary="FAIL"
+if [[ "$SUCCESS" == "0" ]]; then
+  summary="PASS"
+fi
+printf '|%+24s |%+24s |\n' "GORM" $summary >> $HOME/jenkins/summary
 printf '%s\n' "------------- END GORM run ------------------"
 
-echo "Returning $SUCCESS"
 exit $SUCCESS

--- a/init/init.sh
+++ b/init/init.sh
@@ -48,9 +48,7 @@ case $YBDB_IMAGE in
 esac
 
 
-if [ ! -z $YBDB_IMAGE_PATH ]; then
-  # echo "Using Docker Hub image $YBDB_IMAGE_PATH ..."
-else
+if [ -z "$YBDB_IMAGE_PATH" ]; then
   cd $YBDB_CLONE_DIR
   git fetch
 

--- a/init/init.sh
+++ b/init/init.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 
-# Check if Docker image tag input provided.
-if [ -z $YBDB_IMAGE ]; then
-  echo "No YBDB_IMAGE provided. Using the latest master..."
-  YBDB_IMAGE=latest
-fi
-
+YBDB_CLONE_DIR=/var/lib/jenkins/code/yugabyte-db
 YBDB_IMAGE_PREFIX=yugabyte/ecosys-yugabyte:
 YBDB_IMAGE_PATH=
 PHABRICATOR_ID=
-# YBDB_CLONE_DIR is provided by Jenkins configuration
-YBDB_CLONE_DIR=/var/lib/jenkins/code/yugabyte-db
+
+# Check if Docker image tag input provided.
+if [ -z "$YBDB_IMAGE" ]; then
+  echo "No YBDB_IMAGE provided. Using the latest master..."
+  YBDB_IMAGE=latest
+fi
 
 
 # Construct the Docker image path from the input or the default value and check if it exists. Exit if yes.
@@ -23,14 +22,24 @@ case $YBDB_IMAGE in
     # Or ${YBDB_IMAGE#sha_}
     echo "Using the SHA commit $SHA_COMMIT to build the image ..." 
   ;;
-  phd_*)
-    PHABRICATOR_ID="${YBDB_IMAGE:4}"
-    echo "Using phabricator diff id $PHABRICATOR_ID to build the image ..." 
-  ;;
+  # phd_*)
+  #   PHABRICATOR_ID="${YBDB_IMAGE:4}"
+  #   echo "Using phabricator diff id $PHABRICATOR_ID to build the image ..." 
+  #  ;;
   ght_*)
     YBDB_IMAGE_PATH=yugabytedb/yugabyte:${YBDB_IMAGE:4}
     echo "Using Docker Hub image $YBDB_IMAGE_PATH ..."
-    return 0
+    # return 0
+  ;;
+  last_latest)
+    LATEST_IMAGE=$(docker image list --filter=reference="${YBDB_IMAGE_PREFIX}latest" --format "{{.Repository}}:{{.Tag}}")
+    if [ -z "$LATEST_IMAGE" ]; then
+      echo "No Docker image found with 'latest' tag. Building new one with the latest master ..."
+      YBDB_IMAGE=latest
+    else
+      YBDB_IMAGE_PATH=${LATEST_IMAGE}
+      echo "Using the Docker image $YBDB_IMAGE_PATH ..."
+    fi
   ;;
   *)
     echo "Invalid YBDB_IMAGE value: $YBDB_IMAGE. Using the latest master build ..."
@@ -39,57 +48,65 @@ case $YBDB_IMAGE in
 esac
 
 
-cd $YBDB_CLONE_DIR
-git fetch
-
-if [ ! -z "$SHA_COMMIT" ]; then
-  git checkout $SHA_COMMIT
-  echo "Cloned the commit $SHA_COMMIT"
-else
-  git pull
-  echo "Cloned latest master of yugabyte-db repository"
-fi
-
-LATEST=$(git log --pretty=format:"%h" -1)
-TAG_SUFFIX=$LATEST
-if [ ! -z ${PHABRICATOR_ID} ]; then
-  TAG_SUFFIX=$LATEST-${PHABRICATOR_ID}
-fi
-echo "Tag suffix: $TAG_SUFFIX"
-
-YBDB_IMAGE_PATH=$(docker image list --filter=reference="${YBDB_IMAGE_PREFIX}*${TAG_SUFFIX}" --format "{{.Repository}}:{{.Tag}}")
 if [ ! -z $YBDB_IMAGE_PATH ]; then
-  echo "Image built with the given commit exists already: $YB_IMAGE_PATH"
+  # echo "Using Docker Hub image $YBDB_IMAGE_PATH ..."
 else
-  echo "Running yb_build.sh ..."
-  ./yb_build.sh --clean
-  echo "Running yb_release ..."
-  ./yb_release > release.log
+  cd $YBDB_CLONE_DIR
+  git fetch
 
-  # Find and note the path/name of the generated tar.gz file.
-  GENERATED_TAR=$(grep "Generated a package at" release.log | grep -o "/var/lib/jenkins/code/yugabyte-db/build/.*.tar.gz")
-  if [ -z $GENERATED_TAR ]; then
-    echo "Could not generate the yugabyte-db package (.tar.gz) file."
-    # return 1
+  if [ ! -z "$SHA_COMMIT" ]; then
+    git checkout $SHA_COMMIT
+    echo "Cloned the commit $SHA_COMMIT"
   else
-    GENERATED_TAR_NAME=${GENERATED_TAR:40}
-    TAG_VERSION=$(echo $GENERATED_TAR_NAME | awk -F[--] '{print $2}')
-    echo "Tag version: $TAG_VERSION"
-    # rm release.log
+    git checkout master
+    git pull
+    echo "Cloned latest master of yugabyte-db repository"
+  fi
 
-    # Build the Docker image.
-    cd ../devops
-    # ./bin/install_python_requirements.sh
-    # ./bin/install_ansible_requirements.sh
-    cd docker/images/yugabyte
-    mkdir -p packages
-    rm -f packages/*
-    cp $GENERATED_TAR packages/yugabyte-$TAG_VERSION-$TAG_SUFFIX-centos-x86_64.tar.gz
-    # Dockerfile is already modified to replace /home/yugabyte with actual path.
-    echo "Building the docker image ..."
-    docker build -t yugabyte/ecosys-yugabyte:$TAG_VERSION-$TAG_SUFFIX .
+  LATEST=$(git log --pretty=format:"%h" -1)
+  TAG_SUFFIX=$LATEST
+  if [ ! -z ${PHABRICATOR_ID} ]; then
+    TAG_SUFFIX=$LATEST-${PHABRICATOR_ID}
+  fi
+  echo "Tag suffix: $TAG_SUFFIX"
 
-    YBDB_IMAGE_PATH=yugabyte/ecosys-yugabyte:$TAG_VERSION-$TAG_SUFFIX
+  YBDB_IMAGE_PATH=$(docker image list --filter=reference="${YBDB_IMAGE_PREFIX}*${TAG_SUFFIX}" --format "{{.Repository}}:{{.Tag}}")
+  if [ ! -z $YBDB_IMAGE_PATH ]; then
+    echo "Image built with the given commit exists already: $YB_IMAGE_PATH"
+  else
+    echo "Running yb_build.sh ..."
+    ./yb_build.sh --clean > yb_build.log 2>&1
+    echo "Running yb_release ..."
+    ./yb_release > release.log 2>&1
+
+    # Find and note the path/name of the generated tar.gz file.
+    GENERATED_TAR=$(grep "Generated a package at" release.log | grep -o "/var/lib/jenkins/code/yugabyte-db/build/.*.tar.gz")
+    if [ -z $GENERATED_TAR ]; then
+      echo "Could not generate the yugabyte-db package (.tar.gz) file."
+      # return 1
+    else
+      GENERATED_TAR_NAME=${GENERATED_TAR:40}
+      TAG_VERSION=$(echo $GENERATED_TAR_NAME | awk -F[--] '{print $2}')
+      echo "Tag version: $TAG_VERSION"
+      # rm release.log
+
+      # Build the Docker image.
+      cd ../devops
+      # ./bin/install_python_requirements.sh
+      # ./bin/install_ansible_requirements.sh
+      cd docker/images/yugabyte
+      mkdir -p packages
+      rm -f packages/*
+      cp $GENERATED_TAR packages/yugabyte-$TAG_VERSION-$TAG_SUFFIX-centos-x86_64.tar.gz
+      # Dockerfile is already modified to replace /home/yugabyte with actual path.
+      echo "Building the docker image ..."
+      docker build -t ${YBDB_IMAGE_PREFIX}$TAG_VERSION-$TAG_SUFFIX .
+      if [ "${YBDB_IMAGE}" = "latest" ]; then
+        docker image tag ${YBDB_IMAGE_PREFIX}$TAG_VERSION-$TAG_SUFFIX ${YBDB_IMAGE_PREFIX}latest
+      fi
+
+      YBDB_IMAGE_PATH=${YBDB_IMAGE_PREFIX}$TAG_VERSION-$TAG_SUFFIX
+    fi
   fi
 fi
 

--- a/init/init.sh
+++ b/init/init.sh
@@ -72,6 +72,7 @@ if [ -z "$YBDB_IMAGE_PATH" ]; then
     echo "Image built with the given commit exists already: $YBDB_IMAGE_PATH"
   else
     echo "Running yb_build.sh ..."
+    source ~/.bashrc
     ./yb_build.sh --clean > yb_build.log 2>&1
     grep "BUILD SUCCESS" yb_build.log
     if [ $? -ne 0 ]; then

--- a/init/init.sh
+++ b/init/init.sh
@@ -69,7 +69,7 @@ if [ -z "$YBDB_IMAGE_PATH" ]; then
 
   YBDB_IMAGE_PATH=$(docker image list --filter=reference="${YBDB_IMAGE_PREFIX}*${TAG_SUFFIX}" --format "{{.Repository}}:{{.Tag}}")
   if [ ! -z $YBDB_IMAGE_PATH ]; then
-    echo "Image built with the given commit exists already: $YB_IMAGE_PATH"
+    echo "Image built with the given commit exists already: $YBDB_IMAGE_PATH"
   else
     echo "Running yb_build.sh ..."
     ./yb_build.sh --clean > yb_build.log 2>&1

--- a/init/init.sh
+++ b/init/init.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# Check if Docker image tag input provided.
+if [ -z $YBDB_IMAGE ]; then
+  echo "No YBDB_IMAGE provided. Using the latest master..."
+  YBDB_IMAGE=latest
+fi
+
+YBDB_IMAGE_PREFIX=yugabyte/ecosys-yugabyte:
+YBDB_IMAGE_PATH=
+PHABRICATOR_ID=
+# YBDB_CLONE_DIR is provided by Jenkins configuration
+YBDB_CLONE_DIR=/var/lib/jenkins/code/yugabyte-db
+
+
+# Construct the Docker image path from the input or the default value and check if it exists. Exit if yes.
+case $YBDB_IMAGE in
+  latest)
+    echo "Using the latest master to build the image ..." 
+  ;;
+  sha_*)
+    SHA_COMMIT="${YBDB_IMAGE:4}"
+    # Or ${YBDB_IMAGE#sha_}
+    echo "Using the SHA commit $SHA_COMMIT to build the image ..." 
+  ;;
+  phd_*)
+    PHABRICATOR_ID="${YBDB_IMAGE:4}"
+    echo "Using phabricator diff id $PHABRICATOR_ID to build the image ..." 
+  ;;
+  ght_*)
+    YBDB_IMAGE_PATH=yugabytedb/yugabyte:${YBDB_IMAGE:4}
+    echo "Using Docker Hub image $YBDB_IMAGE_PATH ..."
+    return 0
+  ;;
+  *)
+    echo "Invalid YBDB_IMAGE value: $YBDB_IMAGE. Using the latest master build ..."
+    YBDB_IMAGE=latest
+  ;;
+esac
+
+
+cd $YBDB_CLONE_DIR
+git pull
+
+if [ ! -z "$SHA_COMMIT" ]; then
+  git checkout $SHA_COMMIT
+  echo "Cloned the commit $SHA_COMMIT"
+else
+  echo "Cloned latest master of yugabyte-db repository"
+fi
+
+LATEST=$(git log --pretty=format:"%h" -1)
+TAG_SUFFIX=$LATEST
+if [ ! -z ${PHABRICATOR_ID} ]; then
+  TAG_SUFFIX=$LATEST-${PHABRICATOR_ID}
+fi
+echo "Tag suffix is $TAG_SUFFIX"
+
+YBDB_IMAGE_PATH=$(docker image list --filter=reference='$YBDB_IMAGE_PREFIX*$TAG_SUFFIX' --format "{{.Repository}}:{{.Tag}}")
+if [ ! -z $YBDB_IMAGE_PATH ]; then
+  echo "Image built with the given commit exists already: $YB_IMAGE_PATH"
+  return 0
+fi
+
+# Build and package the product.
+./yb_build.sh --clean
+./yb_release > release.log
+
+# Find and note the path/name of the generated tar.gz file.
+GENERATED_TAR=$(grep "Generated a package at" release.log | grep -o "/var/lib/jenkins/code/yugabyte-db/build/.*.tar.gz")
+if [ -z $GENERATED_TAR ]; then
+  echo "Could not generate the yugabyte-db package (.tar.gz) file."
+  return 1
+fi
+GENERATED_TAR_NAME=${GENERATED_TAR:40}
+TAG_VERSION=$(echo $GENERATED_TAR_NAME | awk -F[--] '{print $2}')
+# rm release.log
+
+# Build the Docker image.
+cd ../devops
+# ./bin/install_python_requirements.sh
+# ./bin/install_ansible_requirements.sh
+cd docker/images/yugabyte
+mkdir -p packages
+rm -f packages/*
+cp $GENERATED_TAR packages/yugabyte-$TAG_VERSION-$TAG_SUFFIX-centos-x86_64.tar.gz
+# Dockerfile is already modified to replace /home/yugabyte with actual path.
+docker build -t yugabyte/ecosys-yugabyte:$TAG_VERSION-$TAG_SUFFIX .
+
+YBDB_IMAGE_PATH=yugabyte/ecosys-yugabyte:$TAG_VERSION-$TAG_SUFFIX
+
+

--- a/init/init.sh
+++ b/init/init.sh
@@ -49,14 +49,14 @@ esac
 
 if [ -z "$YBDB_IMAGE_PATH" ]; then
   cd $YBDB_CLONE_DIR
-  git fetch
+  git fetch > /dev/null
 
   if [ ! -z "$SHA_COMMIT" ]; then
     git checkout $SHA_COMMIT
     echo "Cloned the commit $SHA_COMMIT"
   else
     git checkout master
-    git pull
+    git pull > /dev/null
     echo "Cloned latest master of yugabyte-db repository"
   fi
 

--- a/sequelize/start-ybdb.sh
+++ b/sequelize/start-ybdb.sh
@@ -1,14 +1,9 @@
 #!/bin/bash
 set -e
 
-# Check if YBDB_IMAGE is defined. If not set it to a value of your choice.
-if [[ -z $YBDB_IMAGE ]]; then
-  YBDB_IMAGE=latest
-fi
-
 # Start YugabyteDB
 docker run -d --name yugabyte  -p7000:7000 -p9000:9000 -p5433:5433 -p9042:9042 \
- yugabytedb/yugabyte:$YBDB_IMAGE bin/yugabyted start \
+ $YBDB_IMAGE_PATH bin/yugabyted start \
  --daemon=false
 
 # Allow some time for cluster init

--- a/sequelize/start.sh
+++ b/sequelize/start.sh
@@ -16,7 +16,12 @@ SUCCESS="$?"
 printf "Executing tear-down.sh ...\n"
 . ./tear-down.sh
 
+echo "Returning $SUCCESS"
+summary="FAIL"
+if [[ "$SUCCESS" == "0" ]]; then
+  summary="PASS"
+fi
+printf '|%+24s |%+24s |\n' "Sequelize ORM" $summary >> $HOME/jenkins/summary
 printf '%s\n' "------------- END Sequelize run ------------------"
 
-echo "Returning $SUCCESS"
 exit $SUCCESS

--- a/sequelize/start.sh
+++ b/sequelize/start.sh
@@ -9,7 +9,7 @@ CURRENT_DIR_PATH=`realpath $CURRENT_DIR`
 cd $CURRENT_DIR_PATH
 
 # Start the run
-YBDB_IMAGE=$YBDB_IMAGE bash ./do-start.sh
+YBDB_IMAGE_PATH=$YBDB_IMAGE_PATH bash ./do-start.sh
 SUCCESS="$?"
 
 # Tear down the setup

--- a/start.sh
+++ b/start.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
 
+rm -f $HOME/jenkins/summary
 if [[ -z "$YBDB_IMAGE" ]]; then
   YBDB_IMAGE=latest
 fi
 CURRENT_DIR=`dirname $0`
 CURRENT_DIR_PATH=`realpath $CURRENT_DIR`
 
+DOCKER_BUILD_RUN=0
+dockerrun="PASS"
 . ./init/init.sh
 
 if [[ -z "$YBDB_IMAGE_PATH" ]]; then
-  echo "WARNING!"
-  echo "WARNING! No image was built/identified. Using the default one."
-  echo "WARNING!"
+  echo "WARNING! No Docker image was built/identified. Using the default one."
+  DOCKER_BUILD_RUN=1
+  dockerrun="FAIL"
   YBDB_IMAGE_PATH=yugabytedb/yugabyte:latest
 fi
 
@@ -29,5 +32,11 @@ GORM_RUN=$?
 
 popd
 
-EXIT_CODE=`expr $SEQU_RUN + $GORM_RUN`
+echo "----------------------------------------------------"
+echo "                   S U M M A R Y                    "
+echo "----------------------------------------------------"
+printf '|%+24s |%+24s |\n' "Docker Build" $dockerrun
+cat $HOME/jenkins/summary
+
+EXIT_CODE=`expr $SEQU_RUN + $GORM_RUN + $DOCKER_BUILD_RUN`
 exit $EXIT_CODE

--- a/start.sh
+++ b/start.sh
@@ -33,10 +33,11 @@ GORM_RUN=$?
 popd
 
 echo "----------------------------------------------------"
-echo "                   S U M M A R Y                    "
+echo "|                  S U M M A R Y                   |"
 echo "----------------------------------------------------"
 printf '|%+24s |%+24s |\n' "Docker Build" $dockerrun
 cat $HOME/jenkins/summary
+echo "----------------------------------------------------"
 
 EXIT_CODE=`expr $SEQU_RUN + $GORM_RUN + $DOCKER_BUILD_RUN`
 exit $EXIT_CODE

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-YBDB_IMAGE=latest
+if [[ -z "$YBDB_IMAGE" ]]; then
+  YBDB_IMAGE=latest
+fi
 CURRENT_DIR=`dirname $0`
 CURRENT_DIR_PATH=`realpath $CURRENT_DIR`
 

--- a/start.sh
+++ b/start.sh
@@ -4,14 +4,23 @@ YBDB_IMAGE=latest
 CURRENT_DIR=`dirname $0`
 CURRENT_DIR_PATH=`realpath $CURRENT_DIR`
 
+. ./init/init.sh
+
+if [[ -z "$YBDB_IMAGE_PATH" ]]; then
+  echo "WARNING!"
+  echo "WARNING! No image was built/identified. Using the default one."
+  echo "WARNING!"
+  YBDB_IMAGE_PATH=yugabytedb/yugabyte:latest
+fi
+
 pushd $CURRENT_DIR_PATH
 
 # 1. Sequelize
-YBDB_IMAGE=latest bash ./sequelize/start.sh
+YBDB_IMAGE_PATH=$YBDB_IMAGE_PATH bash ./sequelize/start.sh
 SEQU_RUN=$?
 
 # 2. GORM
-YBDB_IMAGE=latest bash ./gorm/start.sh
+YBDB_IMAGE_PATH=$YBDB_IMAGE_PATH bash ./gorm/start.sh
 GORM_RUN=$?
 
 # Add your tool's start script above and save its exit code.

--- a/template/README.md
+++ b/template/README.md
@@ -14,7 +14,7 @@
 
       - [`run-app.sh`](./run-app.sh): Runs the examples/tests for verifying the tool/framework.
 
-        You can either do this directly on the host or inside a Docker container.
+        Does whatever is required to execute the examples/tests.
 
   2. [`tear-down.sh`](./tear-down.sh): Cleans up the setup by stopping processes, containers, etc.
 

--- a/template/start-ybdb.sh
+++ b/template/start-ybdb.sh
@@ -1,14 +1,9 @@
 #!/bin/bash
 set -e
 
-# Check if YBDB_IMAGE is defined. If not set it to a value of your choice.
-if [[ -z $YBDB_IMAGE ]]; then
-  YBDB_IMAGE=latest
-fi
-
 # Start YugabyteDB
 docker run -d --name yugabyte  -p7000:7000 -p9000:9000 -p5433:5433 -p9042:9042 \
- yugabytedb/yugabyte:$YBDB_IMAGE bin/yugabyted start \
+ $YBDB_IMAGE_PATH bin/yugabyted start \
  --daemon=false
 
 # Allow some time for cluster init

--- a/template/start.sh
+++ b/template/start.sh
@@ -9,7 +9,7 @@ CURRENT_DIR_PATH=`realpath $CURRENT_DIR`
 cd $CURRENT_DIR_PATH
 
 # Start the run
-YBDB_IMAGE=$YBDB_IMAGE bash ./do-start.sh
+YBDB_IMAGE_PATH=$YBDB_IMAGE_PATH bash ./do-start.sh
 SUCCESS="$?"
 
 # Tear down the setup

--- a/template/start.sh
+++ b/template/start.sh
@@ -16,7 +16,13 @@ SUCCESS="$?"
 printf "Executing tear-down.sh ...\n"
 . ./tear-down.sh
 
+# Print summary
+echo "Returning $SUCCESS"
+summary="FAIL"
+if [[ "$SUCCESS" == "0" ]]; then
+  summary="PASS"
+fi
+printf '|%+24s |%+24s |\n' "new_tool" $summary >> $HOME/jenkins/summary
 printf '%s\n' "------------- END new_tool run ------------------"
 
-echo "Returning $SUCCESS"
 exit $SUCCESS


### PR DESCRIPTION
Add support for building a custom YBDB Docker image.

The major changes are in `init/init.sh`. It outputs the Docker image details to be used via environment variable `YBDB_IMAGE_PATH`. This is what is passed on to the subsequent scripts.

This script takes the env var `YBDB_IMAGE` as an input and accordingly builds the Docker image. This environment variable can have values in the format below:

| Value | Description |
| ---- |:---:|
| `latest` | Create and use the YugabyteDB Docker image built from _current_ master |
| `sha_<commit-id>` | Create and use the YugabyteDB Docker image built from the given commit id. e.g. `sha_c3cd7a35e` |
| `dht_<tag>` | Use the YuabyteDB image from Docker Hub with the given tag. e.g. `dht_2.4.7.0-b7` |
| `last_latest` | Use the last custom YugabyteDB Docker image built from master, if availble. Else, create a new one |


