### PR TITLE
Update do-start.sh to install cargo

### DIFF
--- a/rust-postgres/do-start.sh
+++ b/rust-postgres/do-start.sh
@@ -3,9 +3,9 @@ set -e
 
 prinf "Installing cargo ...\n"
 curl https://sh.rustup.rs -sSf > cargo_install.sh
-source "$HOME/.cargo/env" > cargo_install.sh
 chmod +x cargo_install.sh
 ./cargo_install.sh -y
+source "$HOME/.cargo/env" 
 prinf "cargo Installed ...\n"
 
 # Start the test/example application and generate reports

--- a/rust-postgres/do-start.sh
+++ b/rust-postgres/do-start.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
 
+prinf "Installing cargo ...\n"
+curl https://sh.rustup.rs -sSf > cargo_install.sh
+source "$HOME/.cargo/env" > cargo_install.sh
+chmod +x cargo_install.sh
+./cargo_install.sh -y
+prinf "cargo Installed ...\n"
+
 # Start the test/example application and generate reports
 printf "Executing run-app.sh ...\n"
 ./run-app.sh

--- a/rust-postgres/do-start.sh
+++ b/rust-postgres/do-start.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -e
 
-prinf "Installing cargo ...\n"
+printf "Installing cargo ...\n"
 curl https://sh.rustup.rs -sSf > cargo_install.sh
 chmod +x cargo_install.sh
 ./cargo_install.sh -y
 source "$HOME/.cargo/env" 
-prinf "cargo Installed ...\n"
+printf "cargo Installed ...\n"
 
 # Start the test/example application and generate reports
 printf "Executing run-app.sh ...\n"


### PR DESCRIPTION
Added commands to install cargo, which is required to run rust-postgres driver examples.