### PR TITLE
Not clone gocql if it is already present

### DIFF
--- a/gocql/run-app.sh
+++ b/gocql/run-app.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
 set -e
 
-echo "Cloning the gocql repository"
-git clone git@github.com:yugabyte/gocql.git
-cd gocql
+DIR="gocql"
+if [ -d "$DIR" ]; then
+ echo "gocql repository is already present"
+ cd gocql
+ git checkout master
+ git pull
+else
+ echo "Cloning the gocql repository"
+ git clone git@github.com:yugabyte/gocql.git
+ cd gocql
+fi
 
 echo "Running tests"
 

--- a/pgx/run-app.sh
+++ b/pgx/run-app.sh
@@ -14,6 +14,8 @@ else
 fi
 
 cd go/pgx
+rm -f go.mod
+rm -f go.sum
 go mod init main
 go mod tidy
 


### PR DESCRIPTION
**Description**
pgx: remove go.mod and go.sum files if driver-examples repo is already present.
gocql: do not clone gocql if it already exists.