### PR TITLE
Fix the liquibase test failure

### DIFF
--- a/liquibase/run-app.sh
+++ b/liquibase/run-app.sh
@@ -9,7 +9,7 @@ $YUGABYTE_HOME_DIRECTORY/bin/ysqlsh -f ./src/test/resources/docker/yugabytedb-in
 echo "Editing the config file"
 
 rm src/test/resources/harness-config.yml && cp $INTEGRATIONS_HOME_DIRECTORY/liquibase/harness-config.yml src/test/resources
-sed -i '' 's@${YUGABYTE_RELEASE_NUMBER}@'"$YUGABYTE_RELEASE_NUMBER"'@' src/test/resources/harness-config.yml
+sed -i 's@${YUGABYTE_RELEASE_NUMBER}@'"$YUGABYTE_RELEASE_NUMBER"'@' src/test/resources/harness-config.yml
 
 echo "Building the Liquibase tests"
 JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp -q clean install

--- a/liquibase/run-app.sh
+++ b/liquibase/run-app.sh
@@ -14,11 +14,24 @@ sed -i 's@${YUGABYTE_RELEASE_NUMBER}@'"$YUGABYTE_RELEASE_NUMBER"'@' src/test/res
 echo "Building the Liquibase tests"
 JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp -q clean install
 echo "Running the Liquibase tests"
-JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp -Dtest=FoundationalExtensionHarnessSuite test > $ARTIFACTS_PATH/liquibasefoundationaltest.txt
+JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp test > $ARTIFACTS_PATH/liquibase_yugabytedb_test_report.txt
+JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp -Dtest=FoundationalExtensionHarnessSuite test > $ARTIFACTS_PATH/liquibase_foundational_test_report.txt
+JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp -Dtest=AdvancedExtensionHarnessSuite test > $ARTIFACTS_PATH/liquibase_advanced_test_report.txt
 
-if [ $(grep -c "BUILD SUCCESS" $ARTIFACTS_PATH/liquibasefoundationaltest.txt) -eq 0 ]
+echo "Checking the Liquibase test reports"
+if [ $(grep -c "BUILD SUCCESS" $ARTIFACTS_PATH/liquibase_yugabytedb_test_report.txt) -eq 0 ]
 then
-  cat $ARTIFACTS_PATH/liquibasefoundationaltest.txt
+  cat $ARTIFACTS_PATH/liquibase_yugabytedb_test_report.txt
+fi
+if [ $(grep -c "BUILD SUCCESS" $ARTIFACTS_PATH/liquibase_foundational_test_report.txt) -eq 0 ]
+then
+  cat $ARTIFACTS_PATH/liquibase_foundational_test_report.txt
+fi
+if [ $(grep -c "BUILD SUCCESS" $ARTIFACTS_PATH/liquibase_advanced_test_report.txt) -eq 0 ]
+then
+  cat $ARTIFACTS_PATH/liquibase_advanced_test_report.txt
 fi
 
-! grep "BUILD FAILURE" $ARTIFACTS_PATH/liquibasefoundationaltest.txt
+! grep "BUILD FAILURE" $ARTIFACTS_PATH/liquibase_yugabytedb_test_report.txt
+! grep "BUILD FAILURE" $ARTIFACTS_PATH/liquibase_foundational_test_report.txt
+! grep "BUILD FAILURE" $ARTIFACTS_PATH/liquibase_advanced_test_report.txt

--- a/liquibase/run-app.sh
+++ b/liquibase/run-app.sh
@@ -10,9 +10,9 @@ echo "Editing the config file"
 
 rm src/test/resources/harness-config.yml && cp $INTEGRATIONS_HOME_DIRECTORY/liquibase/harness-config.yml src/test/resources
 
-echo "Running tests"
-
-JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn clean install
-JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp -Dtest=FoundationalExtensionHarnessSuite test > $ARTIFACTS_PATH/liquibasefoundationaltest.txt
+echo "Building the Liquibase tests"
+JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp -q clean install
+echo "Running the Liquibase tests"
+JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp -Dtest=FoundationalExtensionHarnessSuite test
 
 ! grep "BUILD FAILURE" $ARTIFACTS_PATH/liquibasefoundationaltest.txt

--- a/liquibase/run-app.sh
+++ b/liquibase/run-app.sh
@@ -3,7 +3,7 @@ set -e
 
 echo "Cloning the liquibase extension repository"
 
-git clone git@github.com:liquibase/liquibase-yugabytedb.git && cd liquibase-yugabytedb
+git clone -q git@github.com:liquibase/liquibase-yugabytedb.git && cd liquibase-yugabytedb
 $YUGABYTE_HOME_DIRECTORY/bin/ysqlsh -f ./src/test/resources/docker/yugabytedb-init.sql
 
 echo "Editing the config file"
@@ -12,7 +12,7 @@ rm src/test/resources/harness-config.yml && cp $INTEGRATIONS_HOME_DIRECTORY/liqu
 
 echo "Running tests"
 
-mvn clean install
-mvn -ntp -Dtest=FoundationalExtensionHarnessSuite test > $ARTIFACTS_PATH/liquibasefoundationaltest.txt
+JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn clean install
+JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp -Dtest=FoundationalExtensionHarnessSuite test > $ARTIFACTS_PATH/liquibasefoundationaltest.txt
 
 ! grep "BUILD FAILURE" $ARTIFACTS_PATH/liquibasefoundationaltest.txt

--- a/liquibase/run-app.sh
+++ b/liquibase/run-app.sh
@@ -9,10 +9,16 @@ $YUGABYTE_HOME_DIRECTORY/bin/ysqlsh -f ./src/test/resources/docker/yugabytedb-in
 echo "Editing the config file"
 
 rm src/test/resources/harness-config.yml && cp $INTEGRATIONS_HOME_DIRECTORY/liquibase/harness-config.yml src/test/resources
+sed -i '' 's@${YUGABYTE_RELEASE_NUMBER}@'"$YUGABYTE_RELEASE_NUMBER"'@' src/test/resources/harness-config.yml
 
 echo "Building the Liquibase tests"
 JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp -q clean install
 echo "Running the Liquibase tests"
-JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp -Dtest=FoundationalExtensionHarnessSuite test
+JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp -Dtest=FoundationalExtensionHarnessSuite test > $ARTIFACTS_PATH/liquibasefoundationaltest.txt
+
+if [ $(grep -c "BUILD SUCCESS" $ARTIFACTS_PATH/liquibasefoundationaltest.txt) -eq 0 ]
+then
+  cat $ARTIFACTS_PATH/liquibasefoundationaltest.txt
+fi
 
 ! grep "BUILD FAILURE" $ARTIFACTS_PATH/liquibasefoundationaltest.txt

--- a/liquibase/start-ybdb.sh
+++ b/liquibase/start-ybdb.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -e
 
-# Start YugabyteDB
+# Destroy existing YugabyteDB cluster, if any
+$YUGABYTE_HOME_DIRECTORY/bin/yb-ctl destroy
+
+# Start a new YugabyteDB cluster
 $YUGABYTE_HOME_DIRECTORY/bin/yb-ctl create

--- a/liquibase/start.sh
+++ b/liquibase/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-printf '%s\n' "------------- START new_tool run ------------------"
+printf '%s\n' "------------- START Liquibase test run ------------------"
 TOOL_VERSION=
 
 CURRENT_DIR=`dirname $0`
@@ -22,7 +22,7 @@ if [[ "$SUCCESS" == "0" ]]; then
   summary="PASS"
 fi
 printf '%s\n' $summary
-printf '%s\n' "------------- END new_tool run ------------------"
+printf '%s\n' "------------- END Liquibase test run ------------------"
 
 cd ..
 


### PR DESCRIPTION
- Fix: Use Java 11 instead of Java 8 to build the tests successfully.
- Minor improvements