### PR TITLE
Added `partitions_vtable_cache_refresh_secs` flag for gocql test cluster

### DIFF
--- a/gocql/start-ybdb.sh
+++ b/gocql/start-ybdb.sh
@@ -2,4 +2,4 @@
 set -e
 
 # Start YugabyteDB
-$YUGABYTE_HOME_DIRECTORY/bin/yb-ctl create --tserver_flags="cql_nodelist_refresh_interval_secs=8" --master_flags="tserver_unresponsive_timeout_ms=10000"
+$YUGABYTE_HOME_DIRECTORY/bin/yb-ctl create --tserver_flags="cql_nodelist_refresh_interval_secs=8" --master_flags="tserver_unresponsive_timeout_ms=10000, partitions_vtable_cache_refresh_secs=0"


### PR DESCRIPTION
Added partitions_vtable_cache_refresh_secs=0 for gocql test cluster, so that the system.partitions table is updated as soon as there is any schema change in the database. This is required for a gocql test: [TestCreateDropTable](https://github.com/yugabyte/gocql/blob/master/policies_test.go#L389) 