### PR TITLE
Modify version regex to include PG15 versions of YB as well

### DIFF
--- a/django/run-app.sh
+++ b/django/run-app.sh
@@ -13,7 +13,7 @@ export PYTHONUNBUFFERED=1
 #Get YugabyteDB version and set it as environment variable
 
 output=$($YUGABYTE_HOME_DIRECTORY/bin/ysqlsh -c "SELECT version();")
-version=$(echo "$output" | sed -n 's/^.*PostgreSQL 11\.2-YB-\([^ ]*\).*$/\1/p')
+version=$(echo "$output" | sed -n 's/^.*PostgreSQL [^ ]*-YB-\([^ ]*\).*$/\1/p')
 export YB_VERSION=$version
 
 export DJANGO_TESTS_DIR="django_tests_dir"

--- a/node-postgres/run-app.sh
+++ b/node-postgres/run-app.sh
@@ -32,69 +32,117 @@ echo "Running tests"
 
 node yb-fallback-star-1.js > $ARTIFACTS_PATH/yb-fallback-star-1.txt
 
-echo "Test 1 (yb-fallback-star-1) completed"
+if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-fallback-star-1.txt) -eq 0 ]
+then
+  echo "yb-fallback-star-1 failed"
+  cat $ARTIFACTS_PATH/yb-fallback-star-1.txt
+else
+  echo "Test 1 (yb-fallback-star-1) completed"
+fi
 
 node yb-fallback-star-2.js > $ARTIFACTS_PATH/yb-fallback-star-2.txt
 
-echo "Test 2 (yb-fallback-star-2) completed"
-
-node yb-fallback-test-1.js > $ARTIFACTS_PATH/yb-fallback-test-1.txt
-
-echo "Test 3 (yb-fallback-test-1) completed"
-
-node yb-fallback-test-2.js > $ARTIFACTS_PATH/yb-fallback-test-2.txt
-
-echo "Test 4 (yb-fallback-test-2) completed"
-
-node yb-fallback-test-2.js > $ARTIFACTS_PATH/yb-fallback-test-3.txt
-
-echo "Test 5 (yb-fallback-test-2) completed"
+if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-fallback-star-2.txt) -eq 0 ]
+then
+  echo "yyb-fallback-star-2 failed"
+  cat $ARTIFACTS_PATH/yb-fallback-star-2.txt
+else
+  echo "Test 2 (yb-fallback-star-2) completed"
+fi
 
 node yb-fallback-topology-aware-1 > $ARTIFACTS_PATH/yb-fallback-topology-aware-1.txt
 
-echo "Test 6 (yb-fallback-topology-aware-1) completed"
+if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-fallback-topology-aware-1.txt) -eq 0 ]
+then
+  echo "yb-fallback-topology-aware-1 failed"
+  cat $ARTIFACTS_PATH/yb-fallback-topology-aware-1.txt
+else
+  echo "Test 3 (yb-fallback-topology-aware-1) completed"
+fi
 
 node yb-fallback-topology-aware-2.js > $ARTIFACTS_PATH/yb-fallback-topology-aware-2.txt
 
-echo "Test 7 (yb-fallback-topology-aware-2) completed"
+if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-fallback-topology-aware-2.txt) -eq 0 ]
+then
+  echo "yb-fallback-topology-aware-2 failed"
+  cat $ARTIFACTS_PATH/yb-fallback-topology-aware-2.txt
+else
+  echo "Test 4 (yb-fallback-topology-aware-2) completed"
+fi
 
 node yb-fallback-topology-aware-3.js > $ARTIFACTS_PATH/yb-fallback-topology-aware-3.txt
 
-echo "Test 8 (yb-fallback-topology-aware-3) completed"
+if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-fallback-topology-aware-3.txt) -eq 0 ]
+then
+  echo "yb-fallback-topology-aware-3 failed"
+  cat $ARTIFACTS_PATH/yb-fallback-topology-aware-3.txt
+else
+  echo "Test 5 (yb-fallback-topology-aware-3) completed"
+fi
 
 node yb-load-balance-with-add-node.js > $ARTIFACTS_PATH/yb-load-balance-with-add-node.txt
 
-echo "Test 9 (yb-load-balance-with-add-node) completed"
+if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-load-balance-with-add-node.txt) -eq 0 ]
+then
+  echo "yb-load-balance-with-add-node failed"
+  cat $ARTIFACTS_PATH/yb-load-balance-with-add-node.txt
+else
+  echo "Test 6 (yb-load-balance-with-add-node) completed"
+fi
 
 node yb-load-balance-with-stop-node.js > $ARTIFACTS_PATH/yb-load-balance-with-stop-node.txt
 
-echo "Test 10 (yb-load-balance-with-stop-node) completed"
+if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-load-balance-with-stop-node.txt) -eq 0 ]
+then
+  echo "yb-load-balance-with-stop-node failed"
+  cat $ARTIFACTS_PATH/yb-load-balance-with-stop-node.txt
+else
+  echo "Test 7 (yb-load-balance-with-stop-node) completed"
+fi
 
 node yb-pooling-with-load-balance.js > $ARTIFACTS_PATH/yb-pooling-with-load-balance.txt
 
-echo "Test 11 (yb-pooling-with-load-balance) completed"
+if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-pooling-with-load-balance.txt) -eq 0 ]
+then
+  echo "yb-pooling-with-load-balance failed"
+  cat $ARTIFACTS_PATH/yb-pooling-with-load-balance.txt
+else
+  echo "Test 8 (yb-pooling-with-load-balance) completed"
+fi
 
 node yb-pooling-with-topology-aware.js > $ARTIFACTS_PATH/yb-pooling-with-topology-aware.txt
 
-echo "Test 12 (yb-pooling-with-topology-aware) completed"
+if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-pooling-with-topology-aware.txt) -eq 0 ]
+then
+  echo "yb-pooling-with-topology-aware failed"
+  cat $ARTIFACTS_PATH/yb-pooling-with-topology-aware.txt
+else
+  echo "Test 9 (yb-pooling-with-topology-aware) completed"
+fi
 
 node yb-topology-aware-with-add-node.js > $ARTIFACTS_PATH/yb-topology-aware-with-add-node.txt
 
-echo "Test 13 (yb-topology-aware-with-add-node) completed"
+if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-topology-aware-with-add-node.txt) -eq 0 ]
+then
+  echo "yb-topology-aware-with-add-node failed"
+  cat $ARTIFACTS_PATH/yb-topology-aware-with-add-node.txt
+else
+  echo "Test 10 (yb-topology-aware-with-add-node) completed"
+fi
 
 node yb-topology-aware-with-stop-node.js > $ARTIFACTS_PATH/yb-topology-aware-with-stop-node.txt
 
-echo "Test 14 (yb-topology-aware-with-stop-node) completed"
+if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-topology-aware-with-stop-node.txt) -eq 0 ]
+then
+  echo "yb-topology-aware-with-stop-node failed"
+  cat $ARTIFACTS_PATH/yb-topology-aware-with-stop-node.txt
+else
+  echo "Test 11 (yb-topology-aware-with-stop-node) completed"
+fi
 
 grep "Test Completed" $ARTIFACTS_PATH/yb-fallback-star-1.txt
 
 grep "Test Completed" $ARTIFACTS_PATH/yb-fallback-star-2.txt
-
-grep "Test Completed" $ARTIFACTS_PATH/yb-fallback-test-1.txt
-
-grep "Test Completed" $ARTIFACTS_PATH/yb-fallback-test-2.txt
-
-grep "Test Completed" $ARTIFACTS_PATH/yb-fallback-test-3.txt
 
 grep "Test Completed" $ARTIFACTS_PATH/yb-fallback-topology-aware-1.txt
 

--- a/node-postgres/run-app.sh
+++ b/node-postgres/run-app.sh
@@ -32,117 +32,69 @@ echo "Running tests"
 
 node yb-fallback-star-1.js > $ARTIFACTS_PATH/yb-fallback-star-1.txt
 
-if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-fallback-star-1.txt) -eq 0 ]
-then
-  echo "yb-fallback-star-1 failed"
-  cat $ARTIFACTS_PATH/yb-fallback-star-1.txt
-else
-  echo "Test 1 (yb-fallback-star-1) completed"
-fi
+echo "Test 1 (yb-fallback-star-1) completed"
 
 node yb-fallback-star-2.js > $ARTIFACTS_PATH/yb-fallback-star-2.txt
 
-if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-fallback-star-2.txt) -eq 0 ]
-then
-  echo "yyb-fallback-star-2 failed"
-  cat $ARTIFACTS_PATH/yb-fallback-star-2.txt
-else
-  echo "Test 2 (yb-fallback-star-2) completed"
-fi
+echo "Test 2 (yb-fallback-star-2) completed"
+
+node yb-fallback-test-1.js > $ARTIFACTS_PATH/yb-fallback-test-1.txt
+
+echo "Test 3 (yb-fallback-test-1) completed"
+
+node yb-fallback-test-2.js > $ARTIFACTS_PATH/yb-fallback-test-2.txt
+
+echo "Test 4 (yb-fallback-test-2) completed"
+
+node yb-fallback-test-2.js > $ARTIFACTS_PATH/yb-fallback-test-3.txt
+
+echo "Test 5 (yb-fallback-test-2) completed"
 
 node yb-fallback-topology-aware-1 > $ARTIFACTS_PATH/yb-fallback-topology-aware-1.txt
 
-if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-fallback-topology-aware-1.txt) -eq 0 ]
-then
-  echo "yb-fallback-topology-aware-1 failed"
-  cat $ARTIFACTS_PATH/yb-fallback-topology-aware-1.txt
-else
-  echo "Test 3 (yb-fallback-topology-aware-1) completed"
-fi
+echo "Test 6 (yb-fallback-topology-aware-1) completed"
 
 node yb-fallback-topology-aware-2.js > $ARTIFACTS_PATH/yb-fallback-topology-aware-2.txt
 
-if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-fallback-topology-aware-2.txt) -eq 0 ]
-then
-  echo "yb-fallback-topology-aware-2 failed"
-  cat $ARTIFACTS_PATH/yb-fallback-topology-aware-2.txt
-else
-  echo "Test 4 (yb-fallback-topology-aware-2) completed"
-fi
+echo "Test 7 (yb-fallback-topology-aware-2) completed"
 
 node yb-fallback-topology-aware-3.js > $ARTIFACTS_PATH/yb-fallback-topology-aware-3.txt
 
-if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-fallback-topology-aware-3.txt) -eq 0 ]
-then
-  echo "yb-fallback-topology-aware-3 failed"
-  cat $ARTIFACTS_PATH/yb-fallback-topology-aware-3.txt
-else
-  echo "Test 5 (yb-fallback-topology-aware-3) completed"
-fi
+echo "Test 8 (yb-fallback-topology-aware-3) completed"
 
 node yb-load-balance-with-add-node.js > $ARTIFACTS_PATH/yb-load-balance-with-add-node.txt
 
-if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-load-balance-with-add-node.txt) -eq 0 ]
-then
-  echo "yb-load-balance-with-add-node failed"
-  cat $ARTIFACTS_PATH/yb-load-balance-with-add-node.txt
-else
-  echo "Test 6 (yb-load-balance-with-add-node) completed"
-fi
+echo "Test 9 (yb-load-balance-with-add-node) completed"
 
 node yb-load-balance-with-stop-node.js > $ARTIFACTS_PATH/yb-load-balance-with-stop-node.txt
 
-if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-load-balance-with-stop-node.txt) -eq 0 ]
-then
-  echo "yb-load-balance-with-stop-node failed"
-  cat $ARTIFACTS_PATH/yb-load-balance-with-stop-node.txt
-else
-  echo "Test 7 (yb-load-balance-with-stop-node) completed"
-fi
+echo "Test 10 (yb-load-balance-with-stop-node) completed"
 
 node yb-pooling-with-load-balance.js > $ARTIFACTS_PATH/yb-pooling-with-load-balance.txt
 
-if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-pooling-with-load-balance.txt) -eq 0 ]
-then
-  echo "yb-pooling-with-load-balance failed"
-  cat $ARTIFACTS_PATH/yb-pooling-with-load-balance.txt
-else
-  echo "Test 8 (yb-pooling-with-load-balance) completed"
-fi
+echo "Test 11 (yb-pooling-with-load-balance) completed"
 
 node yb-pooling-with-topology-aware.js > $ARTIFACTS_PATH/yb-pooling-with-topology-aware.txt
 
-if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-pooling-with-topology-aware.txt) -eq 0 ]
-then
-  echo "yb-pooling-with-topology-aware failed"
-  cat $ARTIFACTS_PATH/yb-pooling-with-topology-aware.txt
-else
-  echo "Test 9 (yb-pooling-with-topology-aware) completed"
-fi
+echo "Test 12 (yb-pooling-with-topology-aware) completed"
 
 node yb-topology-aware-with-add-node.js > $ARTIFACTS_PATH/yb-topology-aware-with-add-node.txt
 
-if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-topology-aware-with-add-node.txt) -eq 0 ]
-then
-  echo "yb-topology-aware-with-add-node failed"
-  cat $ARTIFACTS_PATH/yb-topology-aware-with-add-node.txt
-else
-  echo "Test 10 (yb-topology-aware-with-add-node) completed"
-fi
+echo "Test 13 (yb-topology-aware-with-add-node) completed"
 
 node yb-topology-aware-with-stop-node.js > $ARTIFACTS_PATH/yb-topology-aware-with-stop-node.txt
 
-if [ $(grep -c "Test Completed" $ARTIFACTS_PATH/yb-topology-aware-with-stop-node.txt) -eq 0 ]
-then
-  echo "yb-topology-aware-with-stop-node failed"
-  cat $ARTIFACTS_PATH/yb-topology-aware-with-stop-node.txt
-else
-  echo "Test 11 (yb-topology-aware-with-stop-node) completed"
-fi
+echo "Test 14 (yb-topology-aware-with-stop-node) completed"
 
 grep "Test Completed" $ARTIFACTS_PATH/yb-fallback-star-1.txt
 
 grep "Test Completed" $ARTIFACTS_PATH/yb-fallback-star-2.txt
+
+grep "Test Completed" $ARTIFACTS_PATH/yb-fallback-test-1.txt
+
+grep "Test Completed" $ARTIFACTS_PATH/yb-fallback-test-2.txt
+
+grep "Test Completed" $ARTIFACTS_PATH/yb-fallback-test-3.txt
 
 grep "Test Completed" $ARTIFACTS_PATH/yb-fallback-topology-aware-1.txt
 


### PR DESCRIPTION
Currently the tests fail for pg15 YB versions because of regex `s/^.*PostgreSQL 11\.2-YB-\([^ ]*\).*$/\1/p` failing for PG!% versions. This PR fixes that.

Test Run build #74: https://jenkins.dev.yugabyte.com/job/users/job/ecosystem-integration-debug/