### PR TITLE
Add support to generate json payloads for tools for yugaboard integration

### DIFF
--- a/flyway/run-app.sh
+++ b/flyway/run-app.sh
@@ -2,6 +2,8 @@
 set -e
 
 DIR="flyway-tests"
+REPORT_FILE="$WORKSPACE/artifacts/test_report_jdbc_ysql.json"
+
 if [ -d "$DIR" ]; then
  echo "$DIR repository is already present"
 else
@@ -16,6 +18,47 @@ git pull
 echo "Building and running the tests..."
 
 export YBDB_PATH=$YUGABYTE_HOME_DIRECTORY
+export JAVA_HOME=/usr/lib/jvm/zulu-17.jdk
 
-JAVA_HOME=/usr/lib/jvm/zulu-17.jdk mvn clean test
+# Function to run individual test cases and capture their results
+run_test() {
+    local test_name=$1
+    local script_name=$2
+
+    # Run the specific test case and capture errors
+    local tname="com.yugabyte.${script_name}#${test_name}"
+    echo "Running ${tname}..."
+    mvn test -Dtest=${tname} 2>&1 | tee ${test_name}.log
+    if ! grep "BUILD SUCCESS" ${test_name}.log; then
+      # Get the lines between 'FAILURE!' and 'BUILD FAILURE' which is the stack trace and replace new lines with '\n'
+      sed -n '/FAILURE!/,/BUILD FAILURE/{/FAILURE!/b;/BUILD FAILURE/b;p}' ${test_name}.log | awk '{printf "%s\\n", $0}' > stack4json.log
+      echo "{ \"test_name\": \"$test_name\", \"script_name\": \"$script_name\", \"result\": \"FAILED\", \"error_stack\": \"$(cat stack4json.log)\" }," >> temp_report.json
+      RESULT=1
+    else
+      echo "{ \"test_name\": \"$test_name\", \"script_name\": \"$script_name\", \"result\": \"PASSED\", \"error_stack\": \"\" }," >> temp_report.json
+    fi
+}
+
+mvn clean compile --no-transfer-progress
+
+echo "[" > temp_report.json
+
+run_test "baselineTest" "TestBaseline"
+run_test "dlabsTest" "TestBaseline"
+run_test "advisoryLockTest" "TestYBLocking"
+
+sed -i '$ s/,$//' temp_report.json # Remove trailing comma from the last JSON object
+echo "]" >> temp_report.json
+
+# Move the temporary report to the final report file
+mv temp_report.json "$REPORT_FILE"
+
+# Display the JSON report
+echo "TEST REPORT -------------------------"
+cat "$REPORT_FILE"
+
+readlink -f "$REPORT_FILE"
+
+exit $RESULT
+
 

--- a/flyway/run-app.sh
+++ b/flyway/run-app.sh
@@ -26,7 +26,7 @@ run_test() {
     local script_name=$2
 
     # Run the specific test case and capture errors
-    local tname="com.yugabyte.${script_name}#${test_name}"
+    local tname="com.yugabyte.${test_name/./#}"
     echo "Running ${tname}..."
     mvn test -Dtest=${tname} 2>&1 | tee ${test_name}.log
     if ! grep "BUILD SUCCESS" ${test_name}.log; then

--- a/flyway/run-app.sh
+++ b/flyway/run-app.sh
@@ -43,9 +43,9 @@ mvn clean compile --no-transfer-progress
 
 echo "[" > temp_report.json
 
-run_test "baselineTest" "TestBaseline"
-run_test "dlabsTest" "TestBaseline"
-run_test "advisoryLockTest" "TestYBLocking"
+run_test "TestBaseline.baselineTest"      "flyway/start.sh"
+run_test "TestBaseline.dlabsTest"         "flyway/start.sh"
+run_test "TestYBLocking.advisoryLockTest" "flyway/start.sh"
 
 sed -i '$ s/,$//' temp_report.json # Remove trailing comma from the last JSON object
 echo "]" >> temp_report.json

--- a/flyway/run-app.sh
+++ b/flyway/run-app.sh
@@ -2,7 +2,7 @@
 set -e
 
 DIR="flyway-tests"
-REPORT_FILE="$WORKSPACE/artifacts/test_report_jdbc_ysql.json"
+REPORT_FILE="$WORKSPACE/artifacts/test_report_flyway_plugin.json"
 
 if [ -d "$DIR" ]; then
  echo "$DIR repository is already present"

--- a/liquibase/generate-report.sh
+++ b/liquibase/generate-report.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Simulate the output by extracting only the lines after "Results :"
+results_line=$(grep -A 2 "Results :" $ARTIFACTS_PATH/liquibase_yugabytedb_test_report.txt | tail -n 1)
+
+echo $results_line
+
+# Extract numbers of tests run, failures, and errors using grep and sed
+tests_run=$(echo $results_line | sed -n 's/.*Tests run: \([0-9]*\),.*/\1/p')
+failures=$(echo $results_line | sed -n 's/.*Failures: \([0-9]*\),.*/\1/p')
+errors=$(echo $results_line | sed -n 's/.*Errors: \([0-9]*\),.*/\1/p')
+
+# Calculate the values
+success=$((tests_run - failures - errors))
+failures_and_errors=$((failures + errors))
+total_tests=$((tests_run))
+
+# Write results to respective files
+echo "$success" > success.txt
+echo "$failures_and_errors" > failures.txt
+echo "$total_tests" > total.txt
+
+echo "Extraction complete. Results are stored in success.txt, failures.txt, and total.txt."

--- a/liquibase/run-app.sh
+++ b/liquibase/run-app.sh
@@ -10,29 +10,19 @@ $YUGABYTE_HOME_DIRECTORY/bin/ysqlsh -f ./src/test/resources/docker/yugabytedb-in
 echo "Editing the config file"
 
 rm src/test/resources/harness-config.yml && cp $INTEGRATIONS_HOME_DIRECTORY/liquibase/harness-config.yml src/test/resources
-sed -i 's@${YUGABYTE_RELEASE_NUMBER}@'"$YUGABYTE_RELEASE_NUMBER"'@' src/test/resources/harness-config.yml
+
 
 echo "Building the Liquibase tests"
-JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp -q clean install
+mvn -ntp -q clean install
 echo "Running the Liquibase tests"
-JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp test 2>&1 | tee $ARTIFACTS_PATH/liquibase_yugabytedb_test_report.txt
-JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp -Dtest=FoundationalExtensionHarnessSuite test 2>&1 | tee $ARTIFACTS_PATH/liquibase_foundational_test_report.txt
-JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp -Dtest=AdvancedExtensionHarnessSuite test 2>&1 | tee $ARTIFACTS_PATH/liquibase_advanced_test_report.txt
+mvn -ntp test 2>&1 | tee $ARTIFACTS_PATH/liquibase_yugabytedb_test_report.txt
 
 echo "Checking the Liquibase test reports"
 if [ $(grep -c "BUILD SUCCESS" $ARTIFACTS_PATH/liquibase_yugabytedb_test_report.txt) -eq 0 ]
 then
   cat $ARTIFACTS_PATH/liquibase_yugabytedb_test_report.txt
 fi
-if [ $(grep -c "BUILD SUCCESS" $ARTIFACTS_PATH/liquibase_foundational_test_report.txt) -eq 0 ]
-then
-  cat $ARTIFACTS_PATH/liquibase_foundational_test_report.txt
-fi
-if [ $(grep -c "BUILD SUCCESS" $ARTIFACTS_PATH/liquibase_advanced_test_report.txt) -eq 0 ]
-then
-  cat $ARTIFACTS_PATH/liquibase_advanced_test_report.txt
-fi
+
+./generate-report.sh
 
 ! grep "BUILD FAILURE" $ARTIFACTS_PATH/liquibase_yugabytedb_test_report.txt
-! grep "BUILD FAILURE" $ARTIFACTS_PATH/liquibase_foundational_test_report.txt
-! grep "BUILD FAILURE" $ARTIFACTS_PATH/liquibase_advanced_test_report.txt

--- a/liquibase/run-app.sh
+++ b/liquibase/run-app.sh
@@ -1,3 +1,12 @@
+#!/bin/bash
+set -e
+
+echo "Cloning the liquibase extension repository"
+
+rm -rf liquibase-yugabytedb
+git clone -q git@github.com:liquibase/liquibase-yugabytedb.git && cd liquibase-yugabytedb
+$YUGABYTE_HOME_DIRECTORY/bin/ysqlsh -f ./src/test/resources/docker/yugabytedb-init.sql
+
 echo "Editing the config file"
 
 rm src/test/resources/harness-config.yml && cp $INTEGRATIONS_HOME_DIRECTORY/liquibase/harness-config.yml src/test/resources

--- a/liquibase/run-app.sh
+++ b/liquibase/run-app.sh
@@ -1,28 +1,29 @@
-#!/bin/bash
-set -e
-
-echo "Cloning the liquibase extension repository"
-
-rm -rf liquibase-yugabytedb
-git clone -q git@github.com:liquibase/liquibase-yugabytedb.git && cd liquibase-yugabytedb
-$YUGABYTE_HOME_DIRECTORY/bin/ysqlsh -f ./src/test/resources/docker/yugabytedb-init.sql
-
 echo "Editing the config file"
 
 rm src/test/resources/harness-config.yml && cp $INTEGRATIONS_HOME_DIRECTORY/liquibase/harness-config.yml src/test/resources
-
+sed -i 's@${YUGABYTE_RELEASE_NUMBER}@'"$YUGABYTE_RELEASE_NUMBER"'@' src/test/resources/harness-config.yml
 
 echo "Building the Liquibase tests"
-mvn -ntp -q clean install
+JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp -q clean install
 echo "Running the Liquibase tests"
-mvn -ntp test 2>&1 | tee $ARTIFACTS_PATH/liquibase_yugabytedb_test_report.txt
+JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp test 2>&1 | tee $ARTIFACTS_PATH/liquibase_yugabytedb_test_report.txt
+JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp -Dtest=FoundationalExtensionHarnessSuite test 2>&1 | tee $ARTIFACTS_PATH/liquibase_foundational_test_report.txt
+JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp -Dtest=AdvancedExtensionHarnessSuite test 2>&1 | tee $ARTIFACTS_PATH/liquibase_advanced_test_report.txt
 
 echo "Checking the Liquibase test reports"
 if [ $(grep -c "BUILD SUCCESS" $ARTIFACTS_PATH/liquibase_yugabytedb_test_report.txt) -eq 0 ]
 then
   cat $ARTIFACTS_PATH/liquibase_yugabytedb_test_report.txt
 fi
-
-./generate-report.sh
+if [ $(grep -c "BUILD SUCCESS" $ARTIFACTS_PATH/liquibase_foundational_test_report.txt) -eq 0 ]
+then
+  cat $ARTIFACTS_PATH/liquibase_foundational_test_report.txt
+fi
+if [ $(grep -c "BUILD SUCCESS" $ARTIFACTS_PATH/liquibase_advanced_test_report.txt) -eq 0 ]
+then
+  cat $ARTIFACTS_PATH/liquibase_advanced_test_report.txt
+fi
 
 ! grep "BUILD FAILURE" $ARTIFACTS_PATH/liquibase_yugabytedb_test_report.txt
+! grep "BUILD FAILURE" $ARTIFACTS_PATH/liquibase_foundational_test_report.txt
+! grep "BUILD FAILURE" $ARTIFACTS_PATH/liquibase_advanced_test_report.txt

--- a/psycopg2/run-app.sh
+++ b/psycopg2/run-app.sh
@@ -64,7 +64,7 @@ run_test "TestTopologyAwareLoadBalancer.test_7" "test_topologyawareloadbalancer"
 run_test "TestMisc.test_2" "test_misc" 2> unittest_error.log
 run_test "TestMisc.test_3" "test_misc" 2> unittest_error.log
 # Finalize the JSON report
-sed -i '' '$ s/,$//' temp_report.json # Remove trailing comma from the last JSON object
+sed -i '$ s/,$//' temp_report.json # Remove trailing comma from the last JSON object
 echo "]" >> temp_report.json
 
 # Move the temporary report to the final report file

--- a/psycopg2/run-app.sh
+++ b/psycopg2/run-app.sh
@@ -17,7 +17,8 @@ run_test() {
     if [ $exit_status -eq 0 ]; then
         echo "{ \"test_name\": \"$test_name\", \"script_name\": \"$script_name.py\", \"result\": \"PASSED\", \"error_stack\": \"\" }," >> temp_report.json
     else
-        echo "{ \"test_name\": \"$test_name\", \"script_name\": \"$script_name.py\", \"result\": \"FAILED\", \"error_stack\": \"$(tail -n 10 unittest_error.log)\" }," >> temp_report.json
+        tail -n 10 unittest_error.log | awk '{printf "%s\\n", $0}' > stack4json.log
+        echo "{ \"test_name\": \"$test_name\", \"script_name\": \"$script_name.py\", \"result\": \"FAILED\", \"error_stack\": \"$(cat stack4json.log)\" }," >> temp_report.json
         OVERALL_STATUS=1
     fi
 }

--- a/psycopg2/run-app.sh
+++ b/psycopg2/run-app.sh
@@ -1,36 +1,59 @@
 #!/bin/bash
 set -e
 
+# Initialize variables
 DIR="driver-examples"
+REPORT_FILE="test_report_psycopg2.json"
+TESTS=("test_uniformloadbalancer.py" "test_topologyawareloadbalancer.py" "test_misc.py")
+REPORT=()
+OVERALL_STATUS=0  # This will be set to 1 if any test fails
+
+# Clone or update the repository
 if [ -d "$DIR" ]; then
- echo "driver-examples repository is already present"
- cd driver-examples
- git checkout main
- git pull
+    echo "driver-examples repository is already present"
+    cd driver-examples
+    git checkout main
+    git pull
 else
- echo "Cloning the driver examples repository"
- git clone git@github.com:yugabyte/driver-examples.git
- cd driver-examples
+    echo "Cloning the driver examples repository"
+    git clone git@github.com:yugabyte/driver-examples.git
+    cd driver-examples
 fi
 
+# Setup Python virtual environment
 cd python-psycopg2/
-
 python3 -m venv $WORKSPACE/environments/psycopg2-test
-
 source $WORKSPACE/environments/psycopg2-test/bin/activate
-
 pip install psycopg2-yugabytedb
 
 export YB_PATH=$YUGABYTE_HOME_DIRECTORY
 
-EXIT_STATUS=0
+# Run tests and collect results
+for TEST_SCRIPT in "${TESTS[@]}"; do
+    TEST_NAME="${TEST_SCRIPT%.*}"  # Extracts 'test_uniformloadbalancer' from 'test_uniformloadbalancer.py'
+    python3 "$TEST_SCRIPT"
+    EXIT_STATUS=$?
 
-python3 test_uniformloadbalancer.py || EXIT_STATUS=$?
+    if [ $EXIT_STATUS -eq 0 ]; then
+        RESULT="PASSED"
+    else
+        RESULT="FAILED"
+        OVERALL_STATUS=1  # Mark overall status as failed if any test fails
+    fi
 
-python3 test_topologyawareloadbalancer.py || EXIT_STATUS=$?
-
-python3 test_misc.py || EXIT_STATUS=$?
+    # Append test result to JSON array
+    REPORT+=("{\"test_name\": \"$TEST_NAME\", \"script_name\": \"$TEST_SCRIPT\", \"result\": \"$RESULT\"}")
+done
 
 deactivate
 
-exit $EXIT_STATUS
+# Generate final JSON report
+echo "[" > $WORKSPACE/artifacts/$REPORT_FILE
+(IFS=,; echo "${REPORT[*]}") >> $WORKSPACE/artifacts/$REPORT_FILE
+echo "]" >> $WORKSPACE/artifacts/$REPORT_FILE
+
+# Display the JSON report
+cat $REPORT_FILE
+
+# Exit with overall status
+exit $OVERALL_STATUS

--- a/psycopg2/run-app.sh
+++ b/psycopg2/run-app.sh
@@ -48,19 +48,19 @@ export YB_PATH=$YUGABYTE_HOME_DIRECTORY
 echo "[" > temp_report.json
 
 # Run all the individual tests you want
-run_test "TestUniformLoadBalancer.test_2" "test_uniformloadbalancer" 2> unittest_error.log
-run_test "TestUniformLoadBalancer.test_3" "test_uniformloadbalancer" 2> unittest_error.log
-run_test "TestUniformLoadBalancer.test_4" "test_uniformloadbalancer" 2> unittest_error.log
-run_test "TestUniformLoadBalancer.test_5" "test_uniformloadbalancer" 2> unittest_error.log
-run_test "TestUniformLoadBalancer.test_6" "test_uniformloadbalancer" 2> unittest_error.log
-run_test "TestUniformLoadBalancer.test_7" "test_uniformloadbalancer" 2> unittest_error.log
+run_test "TestUniformLoadBalancer.test_2" "psycopg2/test_uniformloadbalancer" 2> unittest_error.log
+run_test "TestUniformLoadBalancer.test_3" "psycopg2/test_uniformloadbalancer" 2> unittest_error.log
+run_test "TestUniformLoadBalancer.test_4" "psycopg2/test_uniformloadbalancer" 2> unittest_error.log
+run_test "TestUniformLoadBalancer.test_5" "psycopg2/test_uniformloadbalancer" 2> unittest_error.log
+run_test "TestUniformLoadBalancer.test_6" "psycopg2/test_uniformloadbalancer" 2> unittest_error.log
+run_test "TestUniformLoadBalancer.test_7" "psycopg2/test_uniformloadbalancer" 2> unittest_error.log
 
-run_test "TestTopologyAwareLoadBalancer.test_2" "test_topologyawareloadbalancer" 2> unittest_error.log
-run_test "TestTopologyAwareLoadBalancer.test_3" "test_topologyawareloadbalancer" 2> unittest_error.log
-run_test "TestTopologyAwareLoadBalancer.test_4" "test_topologyawareloadbalancer" 2> unittest_error.log
-run_test "TestTopologyAwareLoadBalancer.test_5" "test_topologyawareloadbalancer" 2> unittest_error.log
-run_test "TestTopologyAwareLoadBalancer.test_6" "test_topologyawareloadbalancer" 2> unittest_error.log
-run_test "TestTopologyAwareLoadBalancer.test_7" "test_topologyawareloadbalancer" 2> unittest_error.log
+run_test "TestTopologyAwareLoadBalancer.test_2" "psycopg2/test_topologyawareloadbalancer" 2> unittest_error.log
+run_test "TestTopologyAwareLoadBalancer.test_3" "psycopg2/test_topologyawareloadbalancer" 2> unittest_error.log
+run_test "TestTopologyAwareLoadBalancer.test_4" "psycopg2/test_topologyawareloadbalancer" 2> unittest_error.log
+run_test "TestTopologyAwareLoadBalancer.test_5" "psycopg2/test_topologyawareloadbalancer" 2> unittest_error.log
+run_test "TestTopologyAwareLoadBalancer.test_6" "psycopg2/test_topologyawareloadbalancer" 2> unittest_error.log
+run_test "TestTopologyAwareLoadBalancer.test_7" "psycopg2/test_topologyawareloadbalancer" 2> unittest_error.log
 
 run_test "TestMisc.test_2" "test_misc" 2> unittest_error.log
 run_test "TestMisc.test_3" "test_misc" 2> unittest_error.log

--- a/psycopg2/run-app.sh
+++ b/psycopg2/run-app.sh
@@ -73,6 +73,8 @@ mv temp_report.json "$REPORT_FILE"
 # Display the JSON report
 cat "$REPORT_FILE"
 
+readlink -f "$REPORT_FILE"
+
 # Deactivate the virtual environment
 deactivate
 

--- a/psycopg2/run-app.sh
+++ b/psycopg2/run-app.sh
@@ -15,7 +15,7 @@ run_test() {
     python3 -m unittest "${script_name}.${test_name}"
     local exit_status=$?
     if [ $exit_status -eq 0 ]; then
-        echo "{ \"test_name\": \"$test_name\", \"script_name\": \"$script_name.py\", \"result\": \"PASSED\", \"error_stack\": \"\" }," >> temp_report.json
+        echo "{ \"test_name\": \"$test_name\", \"script_name\": \"psycopg2/$script_name.py\", \"result\": \"PASSED\", \"error_stack\": \"\" }," >> temp_report.json
     else
         tail -n 10 unittest_error.log | awk '{printf "%s\\n", $0}' > stack4json.log
         echo "{ \"test_name\": \"$test_name\", \"script_name\": \"$script_name.py\", \"result\": \"FAILED\", \"error_stack\": \"$(cat stack4json.log)\" }," >> temp_report.json
@@ -48,19 +48,19 @@ export YB_PATH=$YUGABYTE_HOME_DIRECTORY
 echo "[" > temp_report.json
 
 # Run all the individual tests you want
-run_test "TestUniformLoadBalancer.test_2" "psycopg2/test_uniformloadbalancer" 2> unittest_error.log
-run_test "TestUniformLoadBalancer.test_3" "psycopg2/test_uniformloadbalancer" 2> unittest_error.log
-run_test "TestUniformLoadBalancer.test_4" "psycopg2/test_uniformloadbalancer" 2> unittest_error.log
-run_test "TestUniformLoadBalancer.test_5" "psycopg2/test_uniformloadbalancer" 2> unittest_error.log
-run_test "TestUniformLoadBalancer.test_6" "psycopg2/test_uniformloadbalancer" 2> unittest_error.log
-run_test "TestUniformLoadBalancer.test_7" "psycopg2/test_uniformloadbalancer" 2> unittest_error.log
+run_test "TestUniformLoadBalancer.test_2" "test_uniformloadbalancer" 2> unittest_error.log
+run_test "TestUniformLoadBalancer.test_3" "test_uniformloadbalancer" 2> unittest_error.log
+run_test "TestUniformLoadBalancer.test_4" "test_uniformloadbalancer" 2> unittest_error.log
+run_test "TestUniformLoadBalancer.test_5" "test_uniformloadbalancer" 2> unittest_error.log
+run_test "TestUniformLoadBalancer.test_6" "test_uniformloadbalancer" 2> unittest_error.log
+run_test "TestUniformLoadBalancer.test_7" "test_uniformloadbalancer" 2> unittest_error.log
 
-run_test "TestTopologyAwareLoadBalancer.test_2" "psycopg2/test_topologyawareloadbalancer" 2> unittest_error.log
-run_test "TestTopologyAwareLoadBalancer.test_3" "psycopg2/test_topologyawareloadbalancer" 2> unittest_error.log
-run_test "TestTopologyAwareLoadBalancer.test_4" "psycopg2/test_topologyawareloadbalancer" 2> unittest_error.log
-run_test "TestTopologyAwareLoadBalancer.test_5" "psycopg2/test_topologyawareloadbalancer" 2> unittest_error.log
-run_test "TestTopologyAwareLoadBalancer.test_6" "psycopg2/test_topologyawareloadbalancer" 2> unittest_error.log
-run_test "TestTopologyAwareLoadBalancer.test_7" "psycopg2/test_topologyawareloadbalancer" 2> unittest_error.log
+run_test "TestTopologyAwareLoadBalancer.test_2" "test_topologyawareloadbalancer" 2> unittest_error.log
+run_test "TestTopologyAwareLoadBalancer.test_3" "test_topologyawareloadbalancer" 2> unittest_error.log
+run_test "TestTopologyAwareLoadBalancer.test_4" "test_topologyawareloadbalancer" 2> unittest_error.log
+run_test "TestTopologyAwareLoadBalancer.test_5" "test_topologyawareloadbalancer" 2> unittest_error.log
+run_test "TestTopologyAwareLoadBalancer.test_6" "test_topologyawareloadbalancer" 2> unittest_error.log
+run_test "TestTopologyAwareLoadBalancer.test_7" "test_topologyawareloadbalancer" 2> unittest_error.log
 
 run_test "TestMisc.test_2" "test_misc" 2> unittest_error.log
 run_test "TestMisc.test_3" "test_misc" 2> unittest_error.log

--- a/ysql-jdbc/run-app.sh
+++ b/ysql-jdbc/run-app.sh
@@ -2,6 +2,8 @@
 set -e
 
 DIR="driver-examples"
+REPORT_FILE="$WORKSPACE/artifacts/test_report_jdbc_ysql.json"
+
 if [ -d "$DIR" ]; then
   echo "driver-examples repository is already present"
   cd $DIR
@@ -17,47 +19,45 @@ cd java/ysql-jdbc
 echo "Compiling the YSQL JDBC tests ..."
 mvn clean compile
 
-echo "Running LoadBalanceConcurrencyExample ..."
-YBDB_PATH=$YUGABYTE_HOME_DIRECTORY mvn exec:java -Dexec.mainClass=com.yugabyte.ysql.LoadBalanceConcurrencyExample 2>&1 | tee jdbc-concurrency.log
-
-echo "Running TopologyAwareLBFallbackExample ..."
-YBDB_PATH=$YUGABYTE_HOME_DIRECTORY mvn exec:java -Dexec.mainClass=com.yugabyte.ysql.TopologyAwareLBFallbackExample 2>&1 | tee jdbc-fallback.log
-
-echo "Running TopologyAwareLBFallback2Example ..."
-YBDB_PATH=$YUGABYTE_HOME_DIRECTORY mvn exec:java -Dexec.mainClass=com.yugabyte.ysql.TopologyAwareLBFallback2Example 2>&1 | tee jdbc-fallback2.log
-
-echo "Running ReadReplicaSupportExample..."
-YBDB_PATH=$YUGABYTE_HOME_DIRECTORY mvn exec:java -Dexec.mainClass=com.yugabyte.ysql.ReadReplicaSupportExample 2>&1 | tee read-replica.log
-
-echo "Running ReadReplicaSupportHikariExample..."
-YBDB_PATH=$YUGABYTE_HOME_DIRECTORY mvn exec:java -Dexec.mainClass=com.yugabyte.ysql.ReadReplicaSupportHikariExample 2>&1 | tee read-replica-hikari.log
-
 RESULT=0
 
-if ! grep "BUILD SUCCESS" jdbc-concurrency.log; then
- echo "LoadBalanceConcurrencyExample failed!"
- RESULT=1
-fi
+# Function to run individual test cases and capture their results
+run_test() {
+    local test_name=$1
+    local script_name=$2
+    echo "Running $test_name from $script_name..."
 
-if ! grep "BUILD SUCCESS" jdbc-fallback.log; then
- echo "TopologyAwareLBFallbackExample failed!"
- RESULT=1
-fi
+    # Run the specific test case and capture errors
+    YBDB_PATH=$YUGABYTE_HOME_DIRECTORY mvn exec:java -Dexec.mainClass=com.yugabyte.ysql.${test_name}  2>&1 | tee ${test_name}.log
+    if ! grep "BUILD SUCCESS" ${test_name}.log; then
+      # Get the lines between '[WARNING]' and 'BUILD FAILURE' which is the stack trace and replace new lines with '\n'
+      sed -n '/\[WARNING\]/,/BUILD FAILURE/{/\[WARNING\]/b;/BUILD FAILURE/b;p}' ${test_name}.log | awk '{printf "%s\\n", $0}' > stack4json.log
+      echo "{ \"test_name\": \"$test_name\", \"script_name\": \"$script_name\", \"result\": \"FAILED\", \"error_stack\": \"$(cat stack4json.log)\" }," >> temp_report.json
+      RESULT=1
+    else
+      echo "{ \"test_name\": \"$test_name\", \"script_name\": \"$script_name\", \"result\": \"PASSED\", \"error_stack\": \"\" }," >> temp_report.json
+    fi
+}
 
-if ! grep "BUILD SUCCESS" jdbc-fallback2.log; then
- echo "TopologyAwareLBFallback2Example failed!"
- RESULT=1
-fi
+echo "[" > temp_report.json
 
-if ! grep "BUILD SUCCESS" read-replica.log; then
- echo "ReadReplicaSupportExample failed!"
- RESULT=1
-fi
+run_test "LoadBalanceConcurrencyExample"   "JDBC Smart Driver"
+run_test "TopologyAwareLBFallbackExample"  "JDBC Smart Driver"
+run_test "TopologyAwareLBFallback2Example" "JDBC Smart Driver"
+run_test "ReadReplicaSupportExample"       "JDBC Smart Driver"
+run_test "ReadReplicaSupportHikariExample" "JDBC Smart Driver"
 
-if ! grep "BUILD SUCCESS" read-replica-hikari.log; then
- echo "ReadReplicaSupportHikariExample failed!"
- RESULT=1
-fi
+sed -i '$ s/,$//' temp_report.json # Remove trailing comma from the last JSON object
+echo "]" >> temp_report.json
+
+# Move the temporary report to the final report file
+mv temp_report.json "$REPORT_FILE"
+
+# Display the JSON report
+echo "TEST REPORT -------------------------"
+cat "$REPORT_FILE"
+
+readlink -f "$REPORT_FILE"
 
 exit $RESULT
 

--- a/ysql-jdbc/run-app.sh
+++ b/ysql-jdbc/run-app.sh
@@ -28,7 +28,8 @@ run_test() {
     echo "Running $test_name from $script_name..."
 
     # Run the specific test case and capture errors
-    YBDB_PATH=$YUGABYTE_HOME_DIRECTORY mvn exec:java -Dexec.mainClass=com.yugabyte.ysql.${test_name}  2>&1 | tee ${test_name}.log
+    local tname=${test_name%.main}
+    YBDB_PATH=$YUGABYTE_HOME_DIRECTORY mvn exec:java -Dexec.mainClass=com.yugabyte.ysql.${tname}  2>&1 | tee ${test_name}.log
     if ! grep "BUILD SUCCESS" ${test_name}.log; then
       # Get the lines between '[WARNING]' and 'BUILD FAILURE' which is the stack trace and replace new lines with '\n'
       sed -n '/\[WARNING\]/,/BUILD FAILURE/{/\[WARNING\]/b;/BUILD FAILURE/b;p}' ${test_name}.log | awk '{printf "%s\\n", $0}' > stack4json.log

--- a/ysql-jdbc/run-app.sh
+++ b/ysql-jdbc/run-app.sh
@@ -41,11 +41,11 @@ run_test() {
 
 echo "[" > temp_report.json
 
-run_test "LoadBalanceConcurrencyExample"   "JDBC Smart Driver"
-run_test "TopologyAwareLBFallbackExample"  "JDBC Smart Driver"
-run_test "TopologyAwareLBFallback2Example" "JDBC Smart Driver"
-run_test "ReadReplicaSupportExample"       "JDBC Smart Driver"
-run_test "ReadReplicaSupportHikariExample" "JDBC Smart Driver"
+run_test "LoadBalanceConcurrencyExample.main"   "ysql-jdbc/start.sh"
+run_test "TopologyAwareLBFallbackExample.main"  "ysql-jdbc/start.sh"
+run_test "TopologyAwareLBFallback2Example.main" "ysql-jdbc/start.sh"
+run_test "ReadReplicaSupportExample.main"       "ysql-jdbc/start.sh"
+run_test "ReadReplicaSupportHikariExample.main" "ysql-jdbc/start.sh"
 
 sed -i '$ s/,$//' temp_report.json # Remove trailing comma from the last JSON object
 echo "]" >> temp_report.json


### PR DESCRIPTION
Each of the following tools was modified to generate a final test report in the following format:
```
{ "test_name": "TestUniformLoadBalancer.test_2", "script_name": "psycopg2/test_uniformloadbalancer.py", "result": "PASSED", "error_stack": "" }
```
This is sent to the jenkins pipeline, which generates a payload for each test case based on this json. 

Tools changed:

- Psycopg2
- Flyway
- JDBC Smart Driver