### PR TITLE
Skip ruby tests for YugabyteDB versions based on PG 11.2

### DIFF
--- a/ruby-pg/run-app.sh
+++ b/ruby-pg/run-app.sh
@@ -26,6 +26,7 @@ YB_VERSION=`$YBDB_PATH/bin/ysqlsh -c "select version()" | grep "PostgreSQL 11.2"
 $YBDB_PATH/bin/yb-ctl destroy
 if [[  "$YB_VERSION" ]]; then
   echo "------------ SKIPPING RUBY TESTS SINCE YBDB VERSION IS NOT SUPPORTED ----------"
+  echo "[]" > "$REPORT_FILE"
   exit 0
 fi
 

--- a/ruby-pg/run-app.sh
+++ b/ruby-pg/run-app.sh
@@ -21,10 +21,11 @@ export YBDB_PATH=$YUGABYTE_HOME_DIRECTORY
 $YBDB_PATH/bin/yugabyted destroy
 $YBDB_PATH/bin/yb-ctl destroy
 $YBDB_PATH/bin/yb-ctl start
-sleep 5
-YB_VERSION=`$YBDB_PATH/bin/ysqlsh -c "select version()" | grep "PostgreSQL 11.2"`
+sleep 15
+echo "Checking YugabyteDB's PG version ..."
+YB_VERSION=`$YBDB_PATH/bin/ysqlsh -c "select version()"`
 $YBDB_PATH/bin/yb-ctl destroy
-if [[  "$YB_VERSION" ]]; then
+if grep "PostgreSQL 11.2" <<< "$YB_VERSION"; then
   echo "------------ SKIPPING RUBY TESTS SINCE YBDB VERSION IS NOT SUPPORTED ----------"
   echo "[]" > "$REPORT_FILE"
   exit 0

--- a/ruby-pg/run-app.sh
+++ b/ruby-pg/run-app.sh
@@ -22,7 +22,7 @@ $YBDB_PATH/bin/yugabyted destroy
 $YBDB_PATH/bin/yb-ctl destroy
 $YBDB_PATH/bin/yb-ctl start
 sleep 5
-YB_VERSION=`./bin/ysqlsh -c "select version()" | grep "PostgreSQL 11.2"`
+YB_VERSION=`$YBDB_PATH/bin/ysqlsh -c "select version()" | grep "PostgreSQL 11.2"`
 $YBDB_PATH/bin/yb-ctl destroy
 if [[  "$YB_VERSION" ]]; then
   echo "------------ SKIPPING RUBY TESTS SINCE YBDB VERSION IS NOT SUPPORTED ----------"

--- a/ruby-pg/run-app.sh
+++ b/ruby-pg/run-app.sh
@@ -18,6 +18,17 @@ cd ruby/ysql
 
 export YBDB_PATH=$YUGABYTE_HOME_DIRECTORY
 
+$YBDB_PATH/bin/yugabytedb destroy
+$YBDB_PATH/bin/yb-ctl destroy
+$YBDB_PATH/bin/yb-ctl start
+sleep 5
+YB_VERSION=`./bin/ysqlsh -c "select version()" | grep "PostgreSQL 11.2"`
+$YBDB_PATH/bin/yb-ctl destroy
+if [[  "$YB_VERSION" ]]; then
+  echo "------------ SKIPPING RUBY TESTS SINCE YBDB VERSION IS NOT SUPPORTED ----------"
+  exit 0
+fi
+
 echo "which gem? $(which gem)"
 echo "Gem.user_dir: $(ruby -e 'puts Gem.user_dir')"
 echo "ruby version: $(ruby -v) and gem version: $(gem -v)"

--- a/ruby-pg/run-app.sh
+++ b/ruby-pg/run-app.sh
@@ -18,7 +18,7 @@ cd ruby/ysql
 
 export YBDB_PATH=$YUGABYTE_HOME_DIRECTORY
 
-$YBDB_PATH/bin/yugabytedb destroy
+$YBDB_PATH/bin/yugabyted destroy
 $YBDB_PATH/bin/yb-ctl destroy
 $YBDB_PATH/bin/yb-ctl start
 sleep 5

--- a/ysql-jdbc/run-app.sh
+++ b/ysql-jdbc/run-app.sh
@@ -20,7 +20,7 @@ fi
 cd java/ysql-jdbc
 
 echo "Compiling the YSQL JDBC tests ..."
-mvn clean compile
+mvn clean compile --no-transfer-progress
 
 RESULT=0
 


### PR DESCRIPTION
- Skip ruby tests for YugabyteDB versions based on PG 11.2
- The ruby-pg driver does work with these YugabyteDB versions but the installation using its pg_config fails. Hence skipping the tests
- Verified on the debug pipelines
  - With [PG 11.2](https://jenkins.dev.yugabyte.com/job/users/job/ecosystem-integration-debug/254), tests skipped
  - With [PG 15.2](https://jenkins.dev.yugabyte.com/job/users/job/ecosystem-integration-debug/255), tests run fine
- Change in ysql-jdbc is to silent logs during downloading of dependencies