### PR TITLE
[psycopg2] yugabyted start fails with No module named 'psutil'

### DIFF
--- a/psycopg2/run-app.sh
+++ b/psycopg2/run-app.sh
@@ -41,6 +41,7 @@ cd python-psycopg2/
 python3 -m venv $WORKSPACE/environments/psycopg2-test
 source $WORKSPACE/environments/psycopg2-test/bin/activate
 pip install psycopg2-yugabytedb
+pip install psutil
 
 export YB_PATH=$YUGABYTE_HOME_DIRECTORY
 


### PR DESCRIPTION
With 2.25.1 and 2.25.2, yugabyted start is failing with `No module named 'psutil'` error.

This PR explicitly installs the psutil module to fix the error.

Debug pipeline run: [319](https://jenkins.dev.yugabyte.com/job/users/job/ecosystem-integration-debug/319/) and [320](https://jenkins.dev.yugabyte.com/job/users/job/ecosystem-integration-debug/320/)