### PR TITLE
Upgrade pip to resolve failure

### DIFF
--- a/django/run-app.sh
+++ b/django/run-app.sh
@@ -31,7 +31,7 @@ git clone https://github.com/django/django.git --branch $DJANGO_BRANCH $DJANGO_T
 
 
 cd $DJANGO_TESTS_DIR/django 
-pip3 install -e . 
+pip3 install . 
 pip3 install -r tests/requirements/py3.txt; cd ../../
 
 create_settings() {

--- a/django/run-app.sh
+++ b/django/run-app.sh
@@ -22,7 +22,7 @@ mkdir -p $DJANGO_TESTS_DIR
 git clone git@github.com:yugabyte/yb-django.git
 
 cd yb-django
-
+pip3 install --upgrade pip
 pip3 install -r requirements.txt
 pip3 install -e .
 cd ..
@@ -31,7 +31,7 @@ git clone https://github.com/django/django.git --branch $DJANGO_BRANCH $DJANGO_T
 
 
 cd $DJANGO_TESTS_DIR/django 
-pip3 install . 
+pip3 install -e . 
 pip3 install -r tests/requirements/py3.txt; cd ../../
 
 create_settings() {


### PR DESCRIPTION
`pip3 install -e .` is failing because of the presence of an old pip version (19.3.1) and no setup.py being present in the django repository.  pip 19.3.1 doesn't support editable installs for PEP 517/518 projects
Upgrade the pip version so that the above command works.

Test run: https://jenkins.dev.yugabyte.com/job/users/job/ecosystem-integration-debug/330/