### PR TITLE
[psycopg2] print test run logs on console as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+artifacts
+driver-examples
+environments
+integrations

--- a/psycopg2/run-app.sh
+++ b/psycopg2/run-app.sh
@@ -12,12 +12,12 @@ run_test() {
     echo "Running $test_name from $script_name.py..."
     
     # Run the specific test case and capture errors
-    python3 -m unittest "${script_name}.${test_name}"
-    local exit_status=$?
+    python3 -m unittest "${script_name}.${test_name}" 2>&1 | tee ${script_name}_${test_name}.log
+    local exit_status=${PIPESTATUS[0]}
     if [ $exit_status -eq 0 ]; then
         python $WORKSPACE/integrations/utils/create_json.py --test_name $test_name --script_name psycopg2/$script_name.py --result PASSED >> temp_report.json 
     else
-        sed -n '/Traceback/,$p' unittest_error.log > stack4json.log
+        sed -n '/Traceback/,$p' ${script_name}_${test_name}.log > stack4json.log
         python $WORKSPACE/integrations/utils/create_json.py --test_name $test_name --script_name psycopg2/$script_name.py --result FAILED --file_path stack4json.log >> temp_report.json  
         OVERALL_STATUS=1
     fi
@@ -45,43 +45,47 @@ pip install psutil
 
 export YB_PATH=$YUGABYTE_HOME_DIRECTORY
 
+echo "Running tests"
+
 # Initialize the JSON report
 echo "[" > temp_report.json
 
 # Run all the individual tests you want
-run_test "TestUniformLoadBalancer.test_lb_true" "test_uniformloadbalancer" 2> unittest_error.log
-run_test "TestUniformLoadBalancer.test_lb_true_multithreaded" "test_uniformloadbalancer" 2> unittest_error.log
-run_test "TestUniformLoadBalancer.test_lb_true_node_down" "test_uniformloadbalancer" 2> unittest_error.log
-run_test "TestUniformLoadBalancer.test_lb_true_new_node" "test_uniformloadbalancer" 2> unittest_error.log
-run_test "TestUniformLoadBalancer.test_lb_true_localhost" "test_uniformloadbalancer" 2> unittest_error.log
-run_test "TestUniformLoadBalancer.test_lb_true_pool" "test_uniformloadbalancer" 2> unittest_error.log
+run_test "TestUniformLoadBalancer.test_lb_true" "test_uniformloadbalancer" 
+run_test "TestUniformLoadBalancer.test_lb_true_multithreaded" "test_uniformloadbalancer"
+run_test "TestUniformLoadBalancer.test_lb_true_node_down" "test_uniformloadbalancer"
+run_test "TestUniformLoadBalancer.test_lb_true_new_node" "test_uniformloadbalancer"
+run_test "TestUniformLoadBalancer.test_lb_true_localhost" "test_uniformloadbalancer"
+run_test "TestUniformLoadBalancer.test_lb_true_pool" "test_uniformloadbalancer"
 
-run_test "TestTopologyAwareLoadBalancer.test_topology_aware" "test_topologyawareloadbalancer" 2> unittest_error.log
-run_test "TestTopologyAwareLoadBalancer.test_topology_aware_multithreaded" "test_topologyawareloadbalancer" 2> unittest_error.log
-run_test "TestTopologyAwareLoadBalancer.test_topology_aware_node_down" "test_topologyawareloadbalancer" 2> unittest_error.log
-run_test "TestTopologyAwareLoadBalancer.test_topology_aware_add_node" "test_topologyawareloadbalancer" 2> unittest_error.log
-run_test "TestTopologyAwareLoadBalancer.test_topology_aware_localhost" "test_topologyawareloadbalancer" 2> unittest_error.log
-run_test "TestTopologyAwareLoadBalancer.test_topology_aware_pool" "test_topologyawareloadbalancer" 2> unittest_error.log
+run_test "TestTopologyAwareLoadBalancer.test_topology_aware" "test_topologyawareloadbalancer"
+run_test "TestTopologyAwareLoadBalancer.test_topology_aware_multithreaded" "test_topologyawareloadbalancer"
+run_test "TestTopologyAwareLoadBalancer.test_topology_aware_node_down" "test_topologyawareloadbalancer"
+run_test "TestTopologyAwareLoadBalancer.test_topology_aware_add_node" "test_topologyawareloadbalancer"
+run_test "TestTopologyAwareLoadBalancer.test_topology_aware_localhost" "test_topologyawareloadbalancer"
+run_test "TestTopologyAwareLoadBalancer.test_topology_aware_pool" "test_topologyawareloadbalancer"
 
-run_test "TestMisc.test_default_port_with_cluster_on_different_port" "test_misc" 2> unittest_error.log
-run_test "TestMisc.test_default_port" "test_misc" 2> unittest_error.log
-run_test "TestMisc.test_all_valid_uris" "test_misc" 2> unittest_error.log
+run_test "TestMisc.test_default_port_with_cluster_on_different_port" "test_misc"
+run_test "TestMisc.test_default_port" "test_misc"
+run_test "TestMisc.test_all_valid_uris" "test_misc"
 
-run_test "TestFallbackTopology.test_all_valid_placement_zones" "test_fallback_topology" 2> unittest_error.log
-run_test "TestFallbackTopology.test_fallback" "test_fallback_topology" 2> unittest_error.log
-run_test "TestFallbackTopology.test_multilevel_fallback_with_node_up" "test_fallback_topology" 2> unittest_error.log
+run_test "TestFallbackTopology.test_all_valid_placement_zones" "test_fallback_topology"
+run_test "TestFallbackTopology.test_fallback" "test_fallback_topology"
+run_test "TestFallbackTopology.test_multilevel_fallback_with_node_up" "test_fallback_topology"
 
-run_test "TestClusterAwareRR.test_cluster_aware_rr_all_cases" "test_cluster_aware_rr" 2> unittest_error.log
+run_test "TestClusterAwareRR.test_cluster_aware_rr_all_cases" "test_cluster_aware_rr"
 
-run_test "TestTopologyAwareRR.test_topology_aware_rr_all_cases" "test_topology_aware_rr" 2> unittest_error.log
+run_test "TestTopologyAwareRR.test_topology_aware_rr_all_cases" "test_topology_aware_rr"
 # Finalize the JSON report
 sed -i '$ s/,$//' temp_report.json # Remove trailing comma from the last JSON object
 echo "]" >> temp_report.json
+sed -i 's/\t/    /g' temp_report.json # Replace tabs with spaces
 
 # Move the temporary report to the final report file
 mv temp_report.json "$REPORT_FILE"
 
 # Display the JSON report
+echo "TEST REPORT -------------------------"
 cat "$REPORT_FILE"
 
 readlink -f "$REPORT_FILE"

--- a/psycopg2/run-app.sh
+++ b/psycopg2/run-app.sh
@@ -27,12 +27,13 @@ run_test() {
 if [ -d "$DIR" ]; then
     echo "driver-examples repository is already present"
     cd driver-examples
-    git checkout main
+    git checkout psycopg2-fix
     git pull
 else
     echo "Cloning the driver examples repository"
     git clone git@github.com:yugabyte/driver-examples.git
     cd driver-examples
+    git checkout psycopg2-fix
 fi
 
 cd python-psycopg2/

--- a/psycopg2/run-app.sh
+++ b/psycopg2/run-app.sh
@@ -27,8 +27,8 @@ run_test() {
 if [ -d "$DIR" ]; then
     echo "driver-examples repository is already present"
     cd driver-examples
-    git checkout psycopg2-fix
     git pull
+    git checkout psycopg2-fix
 else
     echo "Cloning the driver examples repository"
     git clone git@github.com:yugabyte/driver-examples.git

--- a/psycopg2/run-app.sh
+++ b/psycopg2/run-app.sh
@@ -51,31 +51,31 @@ echo "Running tests"
 echo "[" > temp_report.json
 
 # Run all the individual tests you want
-run_test "TestUniformLoadBalancer.test_lb_true" "test_uniformloadbalancer" 
-run_test "TestUniformLoadBalancer.test_lb_true_multithreaded" "test_uniformloadbalancer"
-run_test "TestUniformLoadBalancer.test_lb_true_node_down" "test_uniformloadbalancer"
-run_test "TestUniformLoadBalancer.test_lb_true_new_node" "test_uniformloadbalancer"
-run_test "TestUniformLoadBalancer.test_lb_true_localhost" "test_uniformloadbalancer"
-run_test "TestUniformLoadBalancer.test_lb_true_pool" "test_uniformloadbalancer"
+# run_test "TestUniformLoadBalancer.test_lb_true" "test_uniformloadbalancer" 
+# run_test "TestUniformLoadBalancer.test_lb_true_multithreaded" "test_uniformloadbalancer"
+# run_test "TestUniformLoadBalancer.test_lb_true_node_down" "test_uniformloadbalancer"
+# run_test "TestUniformLoadBalancer.test_lb_true_new_node" "test_uniformloadbalancer"
+# run_test "TestUniformLoadBalancer.test_lb_true_localhost" "test_uniformloadbalancer"
+# run_test "TestUniformLoadBalancer.test_lb_true_pool" "test_uniformloadbalancer"
 
-run_test "TestTopologyAwareLoadBalancer.test_topology_aware" "test_topologyawareloadbalancer"
-run_test "TestTopologyAwareLoadBalancer.test_topology_aware_multithreaded" "test_topologyawareloadbalancer"
-run_test "TestTopologyAwareLoadBalancer.test_topology_aware_node_down" "test_topologyawareloadbalancer"
-run_test "TestTopologyAwareLoadBalancer.test_topology_aware_add_node" "test_topologyawareloadbalancer"
-run_test "TestTopologyAwareLoadBalancer.test_topology_aware_localhost" "test_topologyawareloadbalancer"
-run_test "TestTopologyAwareLoadBalancer.test_topology_aware_pool" "test_topologyawareloadbalancer"
+# run_test "TestTopologyAwareLoadBalancer.test_topology_aware" "test_topologyawareloadbalancer"
+# run_test "TestTopologyAwareLoadBalancer.test_topology_aware_multithreaded" "test_topologyawareloadbalancer"
+# run_test "TestTopologyAwareLoadBalancer.test_topology_aware_node_down" "test_topologyawareloadbalancer"
+# run_test "TestTopologyAwareLoadBalancer.test_topology_aware_add_node" "test_topologyawareloadbalancer"
+# run_test "TestTopologyAwareLoadBalancer.test_topology_aware_localhost" "test_topologyawareloadbalancer"
+# run_test "TestTopologyAwareLoadBalancer.test_topology_aware_pool" "test_topologyawareloadbalancer"
 
-run_test "TestMisc.test_default_port_with_cluster_on_different_port" "test_misc"
-run_test "TestMisc.test_default_port" "test_misc"
-run_test "TestMisc.test_all_valid_uris" "test_misc"
+# run_test "TestMisc.test_default_port_with_cluster_on_different_port" "test_misc"
+# run_test "TestMisc.test_default_port" "test_misc"
+# run_test "TestMisc.test_all_valid_uris" "test_misc"
 
-run_test "TestFallbackTopology.test_all_valid_placement_zones" "test_fallback_topology"
+# run_test "TestFallbackTopology.test_all_valid_placement_zones" "test_fallback_topology"
 run_test "TestFallbackTopology.test_fallback" "test_fallback_topology"
-run_test "TestFallbackTopology.test_multilevel_fallback_with_node_up" "test_fallback_topology"
+# run_test "TestFallbackTopology.test_multilevel_fallback_with_node_up" "test_fallback_topology"
 
-run_test "TestClusterAwareRR.test_cluster_aware_rr_all_cases" "test_cluster_aware_rr"
+# run_test "TestClusterAwareRR.test_cluster_aware_rr_all_cases" "test_cluster_aware_rr"
 
-run_test "TestTopologyAwareRR.test_topology_aware_rr_all_cases" "test_topology_aware_rr"
+# run_test "TestTopologyAwareRR.test_topology_aware_rr_all_cases" "test_topology_aware_rr"
 # Finalize the JSON report
 sed -i '$ s/,$//' temp_report.json # Remove trailing comma from the last JSON object
 echo "]" >> temp_report.json

--- a/psycopg2/run-app.sh
+++ b/psycopg2/run-app.sh
@@ -52,31 +52,31 @@ echo "Running tests"
 echo "[" > temp_report.json
 
 # Run all the individual tests you want
-# run_test "TestUniformLoadBalancer.test_lb_true" "test_uniformloadbalancer" 
-# run_test "TestUniformLoadBalancer.test_lb_true_multithreaded" "test_uniformloadbalancer"
-# run_test "TestUniformLoadBalancer.test_lb_true_node_down" "test_uniformloadbalancer"
-# run_test "TestUniformLoadBalancer.test_lb_true_new_node" "test_uniformloadbalancer"
-# run_test "TestUniformLoadBalancer.test_lb_true_localhost" "test_uniformloadbalancer"
-# run_test "TestUniformLoadBalancer.test_lb_true_pool" "test_uniformloadbalancer"
+run_test "TestUniformLoadBalancer.test_lb_true" "test_uniformloadbalancer" 
+run_test "TestUniformLoadBalancer.test_lb_true_multithreaded" "test_uniformloadbalancer"
+run_test "TestUniformLoadBalancer.test_lb_true_node_down" "test_uniformloadbalancer"
+run_test "TestUniformLoadBalancer.test_lb_true_new_node" "test_uniformloadbalancer"
+run_test "TestUniformLoadBalancer.test_lb_true_localhost" "test_uniformloadbalancer"
+run_test "TestUniformLoadBalancer.test_lb_true_pool" "test_uniformloadbalancer"
 
-# run_test "TestTopologyAwareLoadBalancer.test_topology_aware" "test_topologyawareloadbalancer"
-# run_test "TestTopologyAwareLoadBalancer.test_topology_aware_multithreaded" "test_topologyawareloadbalancer"
-# run_test "TestTopologyAwareLoadBalancer.test_topology_aware_node_down" "test_topologyawareloadbalancer"
-# run_test "TestTopologyAwareLoadBalancer.test_topology_aware_add_node" "test_topologyawareloadbalancer"
-# run_test "TestTopologyAwareLoadBalancer.test_topology_aware_localhost" "test_topologyawareloadbalancer"
-# run_test "TestTopologyAwareLoadBalancer.test_topology_aware_pool" "test_topologyawareloadbalancer"
+run_test "TestTopologyAwareLoadBalancer.test_topology_aware" "test_topologyawareloadbalancer"
+run_test "TestTopologyAwareLoadBalancer.test_topology_aware_multithreaded" "test_topologyawareloadbalancer"
+run_test "TestTopologyAwareLoadBalancer.test_topology_aware_node_down" "test_topologyawareloadbalancer"
+run_test "TestTopologyAwareLoadBalancer.test_topology_aware_add_node" "test_topologyawareloadbalancer"
+run_test "TestTopologyAwareLoadBalancer.test_topology_aware_localhost" "test_topologyawareloadbalancer"
+run_test "TestTopologyAwareLoadBalancer.test_topology_aware_pool" "test_topologyawareloadbalancer"
 
-# run_test "TestMisc.test_default_port_with_cluster_on_different_port" "test_misc"
-# run_test "TestMisc.test_default_port" "test_misc"
-# run_test "TestMisc.test_all_valid_uris" "test_misc"
+run_test "TestMisc.test_default_port_with_cluster_on_different_port" "test_misc"
+run_test "TestMisc.test_default_port" "test_misc"
+run_test "TestMisc.test_all_valid_uris" "test_misc"
 
-# run_test "TestFallbackTopology.test_all_valid_placement_zones" "test_fallback_topology"
+run_test "TestFallbackTopology.test_all_valid_placement_zones" "test_fallback_topology"
 run_test "TestFallbackTopology.test_fallback" "test_fallback_topology"
-# run_test "TestFallbackTopology.test_multilevel_fallback_with_node_up" "test_fallback_topology"
+run_test "TestFallbackTopology.test_multilevel_fallback_with_node_up" "test_fallback_topology"
 
-# run_test "TestClusterAwareRR.test_cluster_aware_rr_all_cases" "test_cluster_aware_rr"
+run_test "TestClusterAwareRR.test_cluster_aware_rr_all_cases" "test_cluster_aware_rr"
 
-# run_test "TestTopologyAwareRR.test_topology_aware_rr_all_cases" "test_topology_aware_rr"
+run_test "TestTopologyAwareRR.test_topology_aware_rr_all_cases" "test_topology_aware_rr"
 # Finalize the JSON report
 sed -i '$ s/,$//' temp_report.json # Remove trailing comma from the last JSON object
 echo "]" >> temp_report.json

--- a/psycopg2/run-app.sh
+++ b/psycopg2/run-app.sh
@@ -27,13 +27,12 @@ run_test() {
 if [ -d "$DIR" ]; then
     echo "driver-examples repository is already present"
     cd driver-examples
+    git checkout main
     git pull
-    git checkout psycopg2-fix
 else
     echo "Cloning the driver examples repository"
     git clone git@github.com:yugabyte/driver-examples.git
     cd driver-examples
-    git checkout psycopg2-fix
 fi
 
 cd python-psycopg2/


### PR DESCRIPTION
This PR changes the run-app.sh script for psycopg2 to print the test run output on console as well as putting those in a log file to better debug in case of failure.
Debug pipeline run: [336](https://jenkins.dev.yugabyte.com/job/users/job/ecosystem-integration-debug/336/) [337](https://jenkins.dev.yugabyte.com/job/users/job/ecosystem-integration-debug/337/)