### PR TITLE
Fix ruby-pg failure due to older Ruby version

### DIFF
--- a/ruby-pg/run-app.sh
+++ b/ruby-pg/run-app.sh
@@ -43,7 +43,7 @@ gem install yugabytedb-ysql -- --with-pg-config=$YBDB_PATH/postgres/bin/pg_confi
 echo "Installing the concurrent gem..."
 gem install concurrent-ruby
 echo "Installing the pg gem..."
-gem install pg -- --with-pg-config=$YBDB_PATH/postgres/bin/pg_config
+gem install pg -v 1.5.9 -- --with-pg-config=$YBDB_PATH/postgres/bin/pg_config
 
 # Function to run individual test cases and capture their results
 run_test() {


### PR DESCRIPTION
The ruby-pg tests are unable to run due to the following issue:
```
ERROR:  Error installing pg:
17:53:02  	The last version of pg (>= 0) to support your Ruby & RubyGems was 1.5.9. Try installing it with `gem install pg -v 1.5.9` and then running the current command again
17:53:02  	pg requires Ruby version < 3.5.dev, >= 2.7. The current ruby version is 2.5.0.
```
This fix applies the suggested workaround.
This should be good until we update the Jenkins VM to have the latest Ruby version.
The debug build passes: https://jenkins.dev.yugabyte.com/job/users/job/ecosystem-integration-debug/340/