### PR TITLE
Bump Java version to 17 in the liquibase test run script

### DIFF
--- a/liquibase/run-app.sh
+++ b/liquibase/run-app.sh
@@ -14,7 +14,6 @@ rm src/test/resources/harness-config.yml && cp $INTEGRATIONS_HOME_DIRECTORY/liqu
 sed -i 's@${YUGABYTE_RELEASE_NUMBER}@'"$YUGABYTE_RELEASE_NUMBER"'@' src/test/resources/harness-config.yml
 
 echo "Building the Liquibase tests"
-ls /usr/lib/jvm
 JAVA_HOME=/usr/lib/jvm/zulu-17.jdk mvn -ntp -q clean install
 
 # Function to run individual test cases and capture their results

--- a/liquibase/run-app.sh
+++ b/liquibase/run-app.sh
@@ -14,6 +14,7 @@ rm src/test/resources/harness-config.yml && cp $INTEGRATIONS_HOME_DIRECTORY/liqu
 sed -i 's@${YUGABYTE_RELEASE_NUMBER}@'"$YUGABYTE_RELEASE_NUMBER"'@' src/test/resources/harness-config.yml
 
 echo "Building the Liquibase tests"
+ls /usr/lib/jvm
 JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp -q clean install
 
 # Function to run individual test cases and capture their results

--- a/liquibase/run-app.sh
+++ b/liquibase/run-app.sh
@@ -15,7 +15,7 @@ sed -i 's@${YUGABYTE_RELEASE_NUMBER}@'"$YUGABYTE_RELEASE_NUMBER"'@' src/test/res
 
 echo "Building the Liquibase tests"
 ls /usr/lib/jvm
-JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp -q clean install
+JAVA_HOME=/usr/lib/jvm/zulu-17.jdk mvn -ntp -q clean install
 
 # Function to run individual test cases and capture their results
 run_test() {
@@ -30,7 +30,7 @@ run_test() {
     fi
 
     # Run the specific test case and capture errors
-    JAVA_HOME=/usr/lib/jvm/zulu-11.jdk mvn -ntp ${test_name} test 2>&1 | tee ${tc_name}.log
+    JAVA_HOME=/usr/lib/jvm/zulu-17.jdk mvn -ntp ${test_name} test 2>&1 | tee ${tc_name}.log
     
     if ! grep "BUILD SUCCESS" ${tc_name}.log; then
       # Get the lines between 'FAILURE!' and 'BUILD FAILURE' which is the stack trace


### PR DESCRIPTION
The new version of the parent pom of liquibase sets the compile target as 17. The version was updated in our extension a week ago and since then the tests have started failing.

Bumped the JAVA version to fix the issue.

Test run link: https://jenkins.dev.yugabyte.com/job/users/job/ecosystem-integration-debug/343/