### PR TITLE
Enable connection manager for django tests

### DIFF
--- a/django/start-ybdb.sh
+++ b/django/start-ybdb.sh
@@ -2,4 +2,4 @@
 set -e
 
 # Start YugabyteDB
-$YUGABYTE_HOME_DIRECTORY/bin/yb-ctl create
+$YUGABYTE_HOME_DIRECTORY/bin/yugabyted start --tserver_flags "enable_ysql_conn_mgr=true" --ui false

--- a/django/start-ybdb.sh
+++ b/django/start-ybdb.sh
@@ -2,4 +2,5 @@
 set -e
 
 # Start YugabyteDB
+echo "Starting YugabyteDB with connection manager ..."
 $YUGABYTE_HOME_DIRECTORY/bin/yugabyted start --tserver_flags "enable_ysql_conn_mgr=true" --ui false

--- a/django/start-ybdb.sh
+++ b/django/start-ybdb.sh
@@ -3,4 +3,4 @@ set -e
 
 # Start YugabyteDB
 echo "Starting YugabyteDB with connection manager ..."
-$YUGABYTE_HOME_DIRECTORY/bin/yugabyted start --tserver_flags "enable_ysql_conn_mgr=true" --ui false
+$YUGABYTE_HOME_DIRECTORY/bin/yugabyted start --advertise_address=127.0.0.1 --tserver_flags "enable_ysql_conn_mgr=true,allowed_preview_flags_csv=enable_ysql_conn_mgr" --ui false

--- a/django/tear-down.sh
+++ b/django/tear-down.sh
@@ -4,7 +4,7 @@ set -e
 export DJANGO_TESTS_DIR="django_tests_dir"
 
 # Destroy YugabyteDB cluster
-$YUGABYTE_HOME_DIRECTORY/bin/yb-ctl destroy
+$YUGABYTE_HOME_DIRECTORY/bin/yugabyted destroy
 
 rm -rf $WORKSPACE/environments/django-test
 rm -rf $INTEGRATIONS_HOME_DIRECTORY/django/yb-django

--- a/flyway/run-app.sh
+++ b/flyway/run-app.sh
@@ -28,7 +28,7 @@ run_test() {
     # Run the specific test case and capture errors
     local tname="com.yugabyte.${test_name/./#}"
     echo "Running ${tname}..."
-    mvn test -Dtest=${tname} 2>&1 | tee ${test_name}.log
+    mvn test -Dtest=${tname} --no-transfer-progress 2>&1 | tee ${test_name}.log
     if ! grep "BUILD SUCCESS" ${test_name}.log; then
       # Get the lines between 'FAILURE!' and 'BUILD FAILURE' which is the stack trace
       sed -n '/FAILURE!/,/BUILD FAILURE/{/FAILURE!/b;/BUILD FAILURE/b;p}' ${test_name}.log > stack4json.log

--- a/ysql-jdbc/run-app.sh
+++ b/ysql-jdbc/run-app.sh
@@ -32,7 +32,7 @@ run_test() {
 
     # Run the specific test case and capture errors
     local tname=${test_name%.main}
-    YBDB_PATH=$YUGABYTE_HOME_DIRECTORY mvn exec:java -Dexec.mainClass=com.yugabyte.ysql.${tname}  2>&1 | tee ${test_name}.log
+    YBDB_PATH=$YUGABYTE_HOME_DIRECTORY mvn exec:java -Dexec.mainClass=com.yugabyte.ysql.${tname} --no-transfer-progress 2>&1 | tee ${test_name}.log
     if ! grep "BUILD SUCCESS" ${test_name}.log; then
       # Get the lines between '[WARNING]' and 'BUILD FAILURE' which is the stack trace
       sed -n '/\[WARNING\]/,/BUILD FAILURE/{/\[WARNING\]/b;/BUILD FAILURE/b;p}' ${test_name}.log > stack4json.log


### PR DESCRIPTION
- Enable connection manager for django tests
- Skip dependency download progress for mvn commands
- Debug pipeline result: https://jenkins.dev.yugabyte.com/job/users/job/ecosystem-integration-debug/366/
- Changes in flyway and ysql-jdbc are to suppress verbose logging
**Note** The time to run the test suite increased from less than an hour to 4 hours, which needs to be looked into.