### PR TITLE
Enable reading and passing connection manager config via env variable

### DIFF
--- a/django/start-ybdb.sh
+++ b/django/start-ybdb.sh
@@ -4,7 +4,7 @@ set -e
 # Start YugabyteDB
 if [ $ENABLE_CM == "true" ]; then
   echo "Starting YugabyteDB cluster with Connection Manager..."
-  enable_cm_flag='--tserver_flags "enable_ysql_conn_mgr=true,allowed_preview_flags_csv=enable_ysql_conn_mgr"'
+  enable_cm_flag="--tserver_flags enable_ysql_conn_mgr=true,allowed_preview_flags_csv=enable_ysql_conn_mgr"
 fi
 
 $YUGABYTE_HOME_DIRECTORY/bin/yugabyted start --advertise_address=127.0.0.1 $enable_cm_flag --ui false

--- a/django/start-ybdb.sh
+++ b/django/start-ybdb.sh
@@ -2,5 +2,9 @@
 set -e
 
 # Start YugabyteDB
-echo "Starting YugabyteDB with connection manager ..."
-$YUGABYTE_HOME_DIRECTORY/bin/yugabyted start --advertise_address=127.0.0.1 --tserver_flags "enable_ysql_conn_mgr=true,allowed_preview_flags_csv=enable_ysql_conn_mgr" --ui false
+if [ $ENABLE_CM == "true" ]; then
+  echo "Starting YugabyteDB cluster with Connection Manager..."
+  enable_cm_flag='--tserver_flags "enable_ysql_conn_mgr=true,allowed_preview_flags_csv=enable_ysql_conn_mgr"'
+fi
+
+$YUGABYTE_HOME_DIRECTORY/bin/yugabyted start --advertise_address=127.0.0.1 $enable_cm_flag --ui false

--- a/flyway/run-app.sh
+++ b/flyway/run-app.sh
@@ -18,6 +18,7 @@ git pull
 echo "Building and running the tests..."
 
 export YBDB_PATH=$YUGABYTE_HOME_DIRECTORY
+export ENABLE_CM=$ENABLE_CM
 export JAVA_HOME=/usr/lib/jvm/zulu-17.jdk
 
 # Function to run individual test cases and capture their results

--- a/gocql/start-ybdb.sh
+++ b/gocql/start-ybdb.sh
@@ -2,4 +2,9 @@
 set -e
 
 # Start YugabyteDB
-$YUGABYTE_HOME_DIRECTORY/bin/yb-ctl create --tserver_flags="cql_nodelist_refresh_interval_secs=8" --master_flags="tserver_unresponsive_timeout_ms=10000, partitions_vtable_cache_refresh_secs=0"
+if [ $ENABLE_CM == "true" ]; then
+  echo "Starting YugabyteDB cluster with Connection Manager..."
+  enable_cm_flag=",enable_ysql_conn_mgr=true,allowed_preview_flags_csv=enable_ysql_conn_mgr"
+fi
+
+$YUGABYTE_HOME_DIRECTORY/bin/yb-ctl create --tserver_flags="cql_nodelist_refresh_interval_secs=8$enable_cm_flag" --master_flags="tserver_unresponsive_timeout_ms=10000, partitions_vtable_cache_refresh_secs=0"

--- a/gorm/do-start.sh
+++ b/gorm/do-start.sh
@@ -13,7 +13,7 @@ pushd $CURRENT_DIR_PATH
 
 # Launch YugabyteDB
 printf "Executing start-ybdb.sh ...\n"
-. ./start-ybdb.sh
+. ENABLE_CM=$ENABLE_CM ./start-ybdb.sh
 
 # Start the test/example application and generate reports
 printf "Executing run-app.sh ...\n"

--- a/gorm/start-ybdb.sh
+++ b/gorm/start-ybdb.sh
@@ -3,7 +3,7 @@ set -e
 
 if [ $ENABLE_CM == "true" ]; then
   echo "Starting YugabyteDB cluster with Connection Manager..."
-  enable_cm_flag='--tserver_flags "enable_ysql_conn_mgr=true,allowed_preview_flags_csv=enable_ysql_conn_mgr"'
+  enable_cm_flag="--tserver_flags enable_ysql_conn_mgr=true,allowed_preview_flags_csv=enable_ysql_conn_mgr"
 fi
 
 # Start YugabyteDB

--- a/gorm/start-ybdb.sh
+++ b/gorm/start-ybdb.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 set -e
 
+if [ $ENABLE_CM == "true" ]; then
+  echo "Starting YugabyteDB cluster with Connection Manager..."
+  enable_cm_flag='--tserver_flags "enable_ysql_conn_mgr=true,allowed_preview_flags_csv=enable_ysql_conn_mgr"'
+fi
+
 # Start YugabyteDB
 docker run -d --name yugabyte  -p7000:7000 -p9000:9000 -p5433:5433 -p9042:9042 \
- $YBDB_IMAGE_PATH bin/yugabyted start \
+ $YBDB_IMAGE_PATH bin/yugabyted start $enable_cm_flag \
  --background=false
 
 # Allow some time for cluster init

--- a/liquibase/start-ybdb.sh
+++ b/liquibase/start-ybdb.sh
@@ -4,5 +4,10 @@ set -e
 # Destroy existing YugabyteDB cluster, if any
 $YUGABYTE_HOME_DIRECTORY/bin/yb-ctl destroy
 
+if [ $ENABLE_CM == "true" ]; then
+  echo "Starting YugabyteDB cluster with Connection Manager..."
+  enable_cm_flag='--tserver_flags "enable_ysql_conn_mgr=true,allowed_preview_flags_csv=enable_ysql_conn_mgr"'
+fi
+
 # Start a new YugabyteDB cluster
-$YUGABYTE_HOME_DIRECTORY/bin/yb-ctl create
+$YUGABYTE_HOME_DIRECTORY/bin/yb-ctl create $enable_cm_flag

--- a/liquibase/start-ybdb.sh
+++ b/liquibase/start-ybdb.sh
@@ -6,7 +6,7 @@ $YUGABYTE_HOME_DIRECTORY/bin/yb-ctl destroy
 
 if [ $ENABLE_CM == "true" ]; then
   echo "Starting YugabyteDB cluster with Connection Manager..."
-  enable_cm_flag='--tserver_flags "enable_ysql_conn_mgr=true,allowed_preview_flags_csv=enable_ysql_conn_mgr"'
+  enable_cm_flag="--tserver_flags enable_ysql_conn_mgr=true,allowed_preview_flags_csv=enable_ysql_conn_mgr"
 fi
 
 # Start a new YugabyteDB cluster

--- a/node-postgres/run-app.sh
+++ b/node-postgres/run-app.sh
@@ -58,6 +58,7 @@ npm install
 echo "Exporting environment variable YB_PATH with the value of the path of the YugabyteDB installation directory."
 
 export YB_PATH="$YUGABYTE_HOME_DIRECTORY"
+export ENABLE_CM="$ENABLE_CM"
 
 echo "Exporting log level."
 

--- a/node-postgres/run-app.sh
+++ b/node-postgres/run-app.sh
@@ -20,12 +20,13 @@ OVERALL_STATUS=0
 if [ -d "$DIR" ]; then
  echo "driver-examples repository is already present"
  cd driver-examples
- git checkout main
+ git checkout enable-cm-config
  git pull
 else
  echo "Cloning the driver examples repository"
  git clone git@github.com:yugabyte/driver-examples.git
  cd driver-examples
+ git checkout enable-cm-config
 fi
 
 # Function to run individual test cases and capture their results

--- a/node-postgres/run-app.sh
+++ b/node-postgres/run-app.sh
@@ -20,13 +20,13 @@ OVERALL_STATUS=0
 if [ -d "$DIR" ]; then
  echo "driver-examples repository is already present"
  cd driver-examples
- git checkout enable-cm-config
+ git checkout main
  git pull
 else
  echo "Cloning the driver examples repository"
  git clone git@github.com:yugabyte/driver-examples.git
  cd driver-examples
- git checkout enable-cm-config
+ git checkout main
 fi
 
 # Function to run individual test cases and capture their results

--- a/pgx/run-app.sh
+++ b/pgx/run-app.sh
@@ -44,13 +44,13 @@ run_test() {
 if [ -d "$DIR1" ]; then
  echo "driver-examples repository is already present"
  cd driver-examples
- git checkout enable-cm-config
+ git checkout main
  git pull
 else
  echo "Cloning the driver examples repository"
  git clone git@github.com:yugabyte/driver-examples.git
  cd driver-examples
- git checkout enable-cm-config
+ git checkout main
 fi
 
 cd go/pgx

--- a/pgx/run-app.sh
+++ b/pgx/run-app.sh
@@ -44,12 +44,13 @@ run_test() {
 if [ -d "$DIR1" ]; then
  echo "driver-examples repository is already present"
  cd driver-examples
- git checkout main
+ git checkout enable-cm-config
  git pull
 else
  echo "Cloning the driver examples repository"
  git clone git@github.com:yugabyte/driver-examples.git
  cd driver-examples
+ git checkout enable-cm-config
 fi
 
 cd go/pgx

--- a/pgx/run-app.sh
+++ b/pgx/run-app.sh
@@ -6,6 +6,8 @@ DIR2="pgx"
 REPORT_FILE="$WORKSPACE/artifacts/test_report_pgx.json"
 OVERALL_STATUS=0
 
+export ENABLE_CM=$ENABLE_CM
+
 # Function to run individual test cases and capture their results
 run_test() {
     local test_name=$1

--- a/pgx/start-ybdb.sh
+++ b/pgx/start-ybdb.sh
@@ -4,6 +4,12 @@ set -e
 # Start YugabyteDB
 $YUGABYTE_HOME_DIRECTORY/bin/yb-ctl destroy
 $YUGABYTE_HOME_DIRECTORY/bin/yugabyted destroy
-$YUGABYTE_HOME_DIRECTORY/bin/yugabyted start --advertise_address=127.0.0.1 --tserver_flags "enable_ysql_conn_mgr=true,allowed_preview_flags_csv=enable_ysql_conn_mgr"
+# Start YugabyteDB
+if [ $ENABLE_CM == "true" ]; then
+  echo "Starting YugabyteDB cluster with Connection Manager..."
+  enable_cm_flag="--tserver_flags enable_ysql_conn_mgr=true,allowed_preview_flags_csv=enable_ysql_conn_mgr"
+fi
+
+$YUGABYTE_HOME_DIRECTORY/bin/yugabyted start --advertise_address=127.0.0.1 $enable_cm_flag
 sleep 10s
 $YUGABYTE_HOME_DIRECTORY/bin/ysqlsh -c "CREATE DATABASE pgx_test;"

--- a/psycopg2/run-app.sh
+++ b/psycopg2/run-app.sh
@@ -44,6 +44,7 @@ pip install psycopg2-yugabytedb
 pip install psutil
 
 export YB_PATH=$YUGABYTE_HOME_DIRECTORY
+export ENABLE_CM=$ENABLE_CM
 
 echo "Running tests"
 

--- a/ruby-pg/run-app.sh
+++ b/ruby-pg/run-app.sh
@@ -17,6 +17,7 @@ git pull
 cd ruby/ysql
 
 export YBDB_PATH=$YUGABYTE_HOME_DIRECTORY
+export ENABLE_CM=$ENABLE_CM
 
 $YBDB_PATH/bin/yugabyted destroy
 $YBDB_PATH/bin/yb-ctl destroy

--- a/rust-postgres/run-app.sh
+++ b/rust-postgres/run-app.sh
@@ -43,6 +43,7 @@ cargo build
 echo "Exporting environment variable YB_PATH with the value of the path of the YugabyteDB installation directory."
 
 export YB_PATH="$YUGABYTE_HOME_DIRECTORY"
+export ENABLE_CM="$ENABLE_CM"
 
 # Initialize the JSON report
 echo "[" > temp_report.json

--- a/ysql-jdbc/run-app.sh
+++ b/ysql-jdbc/run-app.sh
@@ -10,11 +10,12 @@ REPORT_FILE="$WORKSPACE/artifacts/test_report_jdbc_ysql.json"
 if [ -d "$DIR" ]; then
   echo "driver-examples repository is already present"
   cd $DIR
-  git checkout main
+  git checkout enable-cm-config
   git pull
 else
   echo "Cloning the driver-examples repository ..."
   git clone git@github.com:yugabyte/driver-examples.git && cd driver-examples
+  git checkout enable-cm-config
 fi
 
 cd java/ysql-jdbc

--- a/ysql-jdbc/run-app.sh
+++ b/ysql-jdbc/run-app.sh
@@ -10,12 +10,12 @@ REPORT_FILE="$WORKSPACE/artifacts/test_report_jdbc_ysql.json"
 if [ -d "$DIR" ]; then
   echo "driver-examples repository is already present"
   cd $DIR
-  git checkout enable-cm-config
+  git checkout main
   git pull
 else
   echo "Cloning the driver-examples repository ..."
   git clone git@github.com:yugabyte/driver-examples.git && cd driver-examples
-  git checkout enable-cm-config
+  git checkout main
 fi
 
 cd java/ysql-jdbc

--- a/ysql-jdbc/run-app.sh
+++ b/ysql-jdbc/run-app.sh
@@ -32,7 +32,7 @@ run_test() {
 
     # Run the specific test case and capture errors
     local tname=${test_name%.main}
-    YBDB_PATH=$YUGABYTE_HOME_DIRECTORY mvn exec:java -Dexec.mainClass=com.yugabyte.ysql.${tname} --no-transfer-progress 2>&1 | tee ${test_name}.log
+    ENABLE_CM=$ENABLE_CM YBDB_PATH=$YUGABYTE_HOME_DIRECTORY mvn exec:java -Dexec.mainClass=com.yugabyte.ysql.${tname} --no-transfer-progress 2>&1 | tee ${test_name}.log
     if ! grep "BUILD SUCCESS" ${test_name}.log; then
       # Get the lines between '[WARNING]' and 'BUILD FAILURE' which is the stack trace
       sed -n '/\[WARNING\]/,/BUILD FAILURE/{/\[WARNING\]/b;/BUILD FAILURE/b;p}' ${test_name}.log > stack4json.log


### PR DESCRIPTION
- Enable reading and passing connection manager config via env variable.
- The ENABLE_CM environment variable is passed to all the test jobs, so that each test suite can use it to configure connection manager in the YB cluster for the tests.
- The changes to actually use this env variable will be done in stages, in the driver-examples repo. 
